### PR TITLE
Fix/action stylecheck

### DIFF
--- a/.github/workflows/stylecheck-prs.yml
+++ b/.github/workflows/stylecheck-prs.yml
@@ -4,6 +4,7 @@ on:
     branches: [master]
     paths:
       - '**.md'
+      - '**.ts'
 
 jobs:
   stylecheck:

--- a/src/common/constants_that_require_translations.ts
+++ b/src/common/constants_that_require_translations.ts
@@ -6,4 +6,3 @@ export const LEARNING_RESOURCES = 'Learning Resources';
 export const SEARCH_DOCS = 'Search docs';
 export const TUTORIALS = 'Tutorials';
 export const HOME = 'Home';
-


### PR DESCRIPTION
## Description

Github action stylecheck was only running when `.md` files where changed, but checks themselves were run also on `.ts` files also.

This was producing undesired effects like on this PR](https://github.com/stacks-network/docs/pull/1333) that only modified a `.md` file, but tests failed because of a change on a `.ts`file done on a previous commit.

To fix this and avoid future fails, the stylecheck action will now run whenever `.md` or `.ts` files are modified.