### PR TITLE
Update clarity-reference.json

### DIFF
--- a/src/_data/clarity-reference.json
+++ b/src/_data/clarity-reference.json
@@ -694,7 +694,7 @@
       "output_type": "Not Applicable",
       "signature": "(define-map map-name key-type value-type)",
       "description": "`define-map` is used to define a new datamap for use in a smart contract. Such\nmaps are only modifiable by the current smart contract.\n\nMaps are defined with a key type and value type, often these types are tuple types.\n\nLike other kinds of definition statements, `define-map` may only be used at the top level of a smart contract\ndefinition (i.e., you cannot put a define statement in the middle of a function body).",
-      "example": "\n(define-map squares { x: int } { square: int })\n(define-private (add-entry (x int))\n  (map-insert squares { x: 2 } { square: (* x x) }))\n(add-entry 1)\n(add-entry 2)\n(add-entry 3)\n(add-entry 4)\n(add-entry 5)\n"
+      "example": "\n(define-map squares { x: int } { square: int })\n(define-private (add-entry (x int))\n  (map-insert squares { x: x } { square: (* x x) }))\n(add-entry 1)\n(add-entry 2)\n(add-entry 3)\n(add-entry 4)\n(add-entry 5)\n"
     },
     {
       "name": "define-data-var",


### PR DESCRIPTION
## Description

Fix `define-map` example so that `x` is passed instead of hardcoded `2`.

This way the provided examples return correct result.

```clarity
(define-map squares { x: int } { square: int})

(define-private (add-entry (x int))
  (map-insert squares { x: x } { square: (* x x) }))

(add-entry 1)
(add-entry 2)
(add-entry 3)
(add-entry 4)
(add-entry 5)

(unwrap-panic (map-get? squares { x: 1})) ;; Returns { square:  1}
(unwrap-panic (map-get? squares { x: 2})) ;; Returns { square:  4}
(unwrap-panic (map-get? squares { x: 3})) ;; Returns { square:  9}
(unwrap-panic (map-get? squares { x: 4})) ;; Returns { square: 16}
(unwrap-panic (map-get? squares { x: 5})) ;; Returns { square: 25}
```

/cc @criadoperez @friedger @lgalabru