### PR TITLE
update links

### DIFF
--- a/src/pages/en/write-smart-contracts/tokens.md
+++ b/src/pages/en/write-smart-contracts/tokens.md
@@ -99,5 +99,5 @@ aligned on. With support for this standard across wallets and tools, it becomes 
 [fungible]: #fungible-tokens
 [non-fungible]: #non-fungible-tokens-nfts
 [smart contracts]: /write-smart-contracts/overview
-[sip-010]: https://github.com/hstove/sips/blob/feat/sip-10-ft/sips/sip-010/sip-010-fungible-token-standard.md
-[sip-009]: https://github.com/friedger/sips/blob/main/sips/sips/sip-009-nft-standard.md
+[sip-010]: https://github.com/stacksgov/sips/blob/main/sips/sip-010/sip-010-fungible-token-standard.md
+[sip-009]: https://github.com/stacksgov/sips/blob/main/sips/sip-009/sip-009-nft-standard.md


### PR DESCRIPTION

## Description

Point sip-009 and sip-010 references to official repo at stacksgov instead of @friedger and @hstove repos.

## Checklist

- [ ] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] New links to files and images were verified
- [ ] For fixes/refactors: all existing references were identified and replaced
- [ ] [Style guide](https://developers.google.com/style) was reviewed and applied
- [ ] Clear code samples were provided
- [ ] People were tagged for review
