### PR TITLE
fix: Clarity functions reference autogenerates with bugs #1306

### DIFF
--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -103,7 +103,13 @@ export const TableOfContents = ({
               <Item
                 limit={limit}
                 level={heading.level}
-                slug={slugify(heading.content)}
+                slug={
+                  heading.content[0] === '-'
+                    ? `--${slugify(heading.content)}`
+                    : new RegExp(/\W/).test(heading.content[0])
+                    ? `-${slugify(heading.content)}`
+                    : slugify(heading.content)
+                }
                 label={heading.content}
                 key={index}
               />


### PR DESCRIPTION
I am currently learning Clarity through the Miami Clarity Camp and when I came across the functions section of the docs, I noticed some of the links weren't working. I saw it was an open issue so I decided to work on it. At first, I wanted to fix where the ids are being generated since that is probably where the extras '-' are coming from, but I was not able to find the location. So I decided a quick fix would just be updating where the page links are being generated. I only made changes to the file listed below on line 106. Before the function names get slugified, I made it so that it checks first for a '-' sign since subtract has two '--', then checks for other special characters and prepends the necessary '-' characters to the slugified name if necessary.

src/components/toc.tsx

```
106       slug={slugify(heading.content)}
```

```
106               slug={
107                  heading.content[0] === '-'
108                    ? `--${slugify(heading.content)}`
109                    : new RegExp(/\W/).test(heading.content[0])
110                    ? `-${slugify(heading.content)}`
111                    : slugify(heading.content)
112                }
```

## Checklist

- [ ] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] New links to files and images were verified
- [ ] For fixes/refactors: all existing references were identified and replaced
- [ ] [Style guide](https://developers.google.com/style) was reviewed and applied
- [ ] Clear code samples were provided
- [ ] People were tagged for review

@criadoperez @jhammond2012 