### PR TITLE
log2 description and examples

### DIFF
--- a/docs/write-smart-contracts/clarity-language/language-functions.md
+++ b/docs/write-smart-contracts/clarity-language/language-functions.md
@@ -185,7 +185,7 @@ Returns the largest integer that is less than or equal to the square root of `n`
 #### output: `int | uint`
 #### signature: `(log2 n)`
 #### description:
-Returns the _integer part_ of the power to which the number 2 must be raised to to obtain the value `n`. Fails on zero or a negative numbers.
+Returns the _integer part_ of the power to which the number 2 must be raised to obtain the value `n`. Fails on zero or a negative number.
 #### example: 
 ```clarity
 (log2 u8)   ;; Returns u3

--- a/docs/write-smart-contracts/clarity-language/language-functions.md
+++ b/docs/write-smart-contracts/clarity-language/language-functions.md
@@ -185,12 +185,12 @@ Returns the largest integer that is less than or equal to the square root of `n`
 #### output: `int | uint`
 #### signature: `(log2 n)`
 #### description:
-Returns the power to which the number 2 must be raised to to obtain the value `n`, rounded down to the nearest integer. Fails on a negative numbers.
+Returns the _integer part_ of the power to which the number 2 must be raised to to obtain the value `n`. Fails on zero or a negative numbers.
 #### example: 
 ```clarity
-(log2 u8) ;; Returns u3
-(log2 8) ;; Returns 3
-(log2 u1) ;; Returns u0
+(log2 u8)   ;; Returns u3
+(log2 8)    ;; Returns 3
+(log2 u1)   ;; Returns u0
 (log2 1000) ;; Returns 9
 ```
     


### PR DESCRIPTION
## Description

- Log2 fails on 'Zero' 
- There is no rounding, but striping out the decimal point from result
- Indentation of the output in the example, for readability