### PR TITLE
Update stacks-node start command

### DIFF
--- a/docs/nodes-and-miners/miner-mainnet.md
+++ b/docs/nodes-and-miners/miner-mainnet.md
@@ -176,7 +176,7 @@ burn_fee_cap = 20000
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=$HOME/mainnet-miner-conf.toml
+stacks-node start --config $HOME/mainnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -186,7 +186,7 @@ Your node should start. It will take some time to sync, and then your miner will
 In case you are running into issues or would like to see verbose logging, you can run your node with debug logging enabled. In the command line, run:
 
 ```bash
-STACKS_LOG_DEBUG=1 stacks-node start --config=$HOME/mainnet-miner-conf.toml
+STACKS_LOG_DEBUG=1 stacks-node start --config $HOME/mainnet-miner-conf.toml
 ```
 
 ---

--- a/docs/nodes-and-miners/miner-testnet.md
+++ b/docs/nodes-and-miners/miner-testnet.md
@@ -190,7 +190,7 @@ amount = 10000000000000000
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=$HOME/testnet-miner-conf.toml
+stacks-node start --config $HOME/testnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -200,7 +200,7 @@ Your node should start. It will take some time to sync, and then your miner will
 In case you are running into issues or would like to see verbose logging, you can run your node with debug logging enabled. In the command line, run:
 
 ```bash
-STACKS_LOG_DEBUG=1 stacks-node start --config=$HOME/testnet-miner-conf.toml
+STACKS_LOG_DEBUG=1 stacks-node start --config $HOME/testnet-miner-conf.toml
 ```
 
 ---

--- a/i18n/de/docusaurus-plugin-content-docs/current/blockchain/index.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/blockchain/index.md
@@ -102,7 +102,7 @@ cargo run --bin blockstack-cli publish b8d99fd45da58038d630d9855d3ca2466e8e0f89d
 You can observe the state machine in action locally by running:
 
 ```bash
-cargo stacks-node start --config=./testnet/stacks-node/conf/testnet-follower-conf.toml
+cargo stacks-node start --config ./testnet/stacks-node/conf/testnet-follower-conf.toml
 ```
 
 `testnet-follower-conf.toml` is a configuration file that you can use for setting genesis balances or configuring Event observers. You can grant an address an initial account balance by adding the following entries:

--- a/i18n/de/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
@@ -138,7 +138,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -156,7 +156,7 @@ The above code will compile an optimized binary. To use it, run:
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./mainnet-miner-conf.toml
+./target/release/stacks-node start --config ./mainnet-miner-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the mining guide](../understand-stacks/mining).
@@ -273,7 +273,7 @@ Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` c
 To start your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 :::note
@@ -289,7 +289,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=mainnet-miner-conf.toml
+stacks-node start --config mainnet-miner-conf.toml
 ```
 
 ## Optional: Running with Docker

--- a/i18n/de/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
@@ -132,7 +132,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -150,7 +150,7 @@ The above code will compile an optimized binary. To use it, run:
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./testnet/conf/testnet-follower-conf.toml
+./target/release/stacks-node start --config ./testnet/conf/testnet-follower-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the minig guide](../understand-stacks/mining):
@@ -260,7 +260,7 @@ Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` c
 To start your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 <!-- markdown-link-check-disable -->
@@ -280,7 +280,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=testnet-miner-conf.toml
+stacks-node start --config testnet-miner-conf.toml
 ```
 
 ## Optional: Running with Docker

--- a/i18n/de/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
@@ -65,7 +65,7 @@ Start a node with a config of your own. Can be used for joining a network, start
 Example:
 
 ```bash
-stacks-node start --config=/path/to/config.toml
+stacks-node start --config /path/to/config.toml
 ```
 
 See [Configuration File Options](#configuration-file-options) for more information.

--- a/i18n/es/docusaurus-plugin-content-docs/current/blockchain/index.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/blockchain/index.md
@@ -102,7 +102,7 @@ cargo run --bin blockstack-cli publish b8d99fd45da58038d630d9855d3ca2466e8e0f89d
 You can observe the state machine in action locally by running:
 
 ```bash
-cargo stacks-node start --config=./testnet/stacks-node/conf/testnet-follower-conf.toml
+cargo stacks-node start --config ./testnet/stacks-node/conf/testnet-follower-conf.toml
 ```
 
 `testnet-follower-conf.toml` is a configuration file that you can use for setting genesis balances or configuring Event observers. You can grant an address an initial account balance by adding the following entries:

--- a/i18n/es/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
@@ -109,7 +109,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -127,7 +127,7 @@ The above code will compile an optimized binary. To use it, run:
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./mainnet-miner-conf.toml
+./target/release/stacks-node start --config ./mainnet-miner-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the mining guide](../understand-stacks/mining).
@@ -215,7 +215,7 @@ Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` c
 To start your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 :::note
@@ -231,7 +231,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=mainnet-miner-conf.toml
+stacks-node start --config mainnet-miner-conf.toml
 ```
 
 ## Optional: Running with Docker

--- a/i18n/es/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
@@ -105,7 +105,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -123,7 +123,7 @@ The above code will compile an optimized binary. To use it, run:
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./testnet/conf/testnet-follower-conf.toml
+./target/release/stacks-node start --config ./testnet/conf/testnet-follower-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the minig guide](../understand-stacks/mining):
@@ -206,7 +206,7 @@ Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` c
 To start your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 <!-- markdown-link-check-disable -->
@@ -226,7 +226,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=testnet-miner-conf.toml
+stacks-node start --config testnet-miner-conf.toml
 ```
 
 ## Optional: Running with Docker

--- a/i18n/es/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
@@ -65,7 +65,7 @@ Start a node with a config of your own. Can be used for joining a network, start
 Ejemplo:
 
 ```bash
-stacks-node start --config=/path/to/config.toml
+stacks-node start --config /path/to/config.toml
 ```
 
 See [Configuration File Options](#configuration-file-options) for more information.

--- a/i18n/fr/docusaurus-plugin-content-docs/current/blockchain/index.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/blockchain/index.md
@@ -102,7 +102,7 @@ cargo run --bin blockstack-cli publish b8d99fd45da58038d630d9855d3ca2466e8e0f89d
 Vous pouvez observer la machine d'état en action (localement) en exécutant :
 
 ```bash
-cargo stacks-node start --config=./testnet/stacks-node/conf/testnet-follower-conf.toml
+cargo stacks-node start --config ./testnet/stacks-node/conf/testnet-follower-conf.toml
 ```
 
 `testnet-follower-conf.toml` est un fichier de configuration que vous pouvez utiliser pour mettre en place des balances genesis ou configurer des observateurs d'événements. Vous pouvez accorder à une adresse un solde initial du compte en ajoutant les entrées suivantes:

--- a/i18n/fr/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
@@ -109,7 +109,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -127,7 +127,7 @@ The above code will compile an optimized binary. To use it, run:
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./mainnet-miner-conf.toml
+./target/release/stacks-node start --config ./mainnet-miner-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the mining guide](../understand-stacks/mining).
@@ -215,7 +215,7 @@ Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` c
 To start your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 :::note
@@ -231,7 +231,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=mainnet-miner-conf.toml
+stacks-node start --config mainnet-miner-conf.toml
 ```
 
 ## Optional: Running with Docker

--- a/i18n/fr/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
@@ -105,7 +105,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -123,7 +123,7 @@ The above code will compile an optimized binary. To use it, run:
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./testnet/conf/testnet-follower-conf.toml
+./target/release/stacks-node start --config ./testnet/conf/testnet-follower-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the minig guide](../understand-stacks/mining):
@@ -206,7 +206,7 @@ Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` c
 To start your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 <!-- markdown-link-check-disable -->
@@ -226,7 +226,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=testnet-miner-conf.toml
+stacks-node start --config testnet-miner-conf.toml
 ```
 
 ## Optional: Running with Docker

--- a/i18n/fr/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
@@ -65,7 +65,7 @@ Start a node with a config of your own. Can be used for joining a network, start
 Example:
 
 ```bash
-stacks-node start --config=/path/to/config.toml
+stacks-node start --config /path/to/config.toml
 ```
 
 See [Configuration File Options](#configuration-file-options) for more information.

--- a/i18n/hi/docusaurus-plugin-content-docs/current/blockchain/index.md
+++ b/i18n/hi/docusaurus-plugin-content-docs/current/blockchain/index.md
@@ -102,7 +102,7 @@ cargo run --bin blockstack-cli publish b8d99fd45da58038d630d9855d3ca2466e8e0f89d
 You can observe the state machine in action locally by running:
 
 ```bash
-cargo stacks-node start --config=./testnet/stacks-node/conf/testnet-follower-conf.toml
+cargo stacks-node start --config ./testnet/stacks-node/conf/testnet-follower-conf.toml
 ```
 
 `testnet-follower-conf.toml` is a configuration file that you can use for setting genesis balances or configuring Event observers. You can grant an address an initial account balance by adding the following entries:

--- a/i18n/hi/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
+++ b/i18n/hi/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
@@ -109,7 +109,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -127,7 +127,7 @@ The above code will compile an optimized binary. To use it, run:
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./mainnet-miner-conf.toml
+./target/release/stacks-node start --config ./mainnet-miner-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the mining guide](../understand-stacks/mining).
@@ -215,7 +215,7 @@ Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` c
 To start your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 :::note
@@ -231,7 +231,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=mainnet-miner-conf.toml
+stacks-node start --config mainnet-miner-conf.toml
 ```
 
 ## Optional: Running with Docker

--- a/i18n/hi/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
+++ b/i18n/hi/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
@@ -105,7 +105,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -123,7 +123,7 @@ The above code will compile an optimized binary. To use it, run:
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./testnet/conf/testnet-follower-conf.toml
+./target/release/stacks-node start --config ./testnet/conf/testnet-follower-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the minig guide](../understand-stacks/mining):
@@ -206,7 +206,7 @@ Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` c
 To start your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 <!-- markdown-link-check-disable -->
@@ -226,7 +226,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=testnet-miner-conf.toml
+stacks-node start --config testnet-miner-conf.toml
 ```
 
 ## Optional: Running with Docker

--- a/i18n/hi/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
+++ b/i18n/hi/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
@@ -65,7 +65,7 @@ Start a node with a config of your own. Can be used for joining a network, start
 Example:
 
 ```bash
-stacks-node start --config=/path/to/config.toml
+stacks-node start --config /path/to/config.toml
 ```
 
 See [Configuration File Options](#configuration-file-options) for more information.

--- a/i18n/id/docusaurus-plugin-content-docs/current/blockchain/index.md
+++ b/i18n/id/docusaurus-plugin-content-docs/current/blockchain/index.md
@@ -102,7 +102,7 @@ cargo run --bin blockstack-cli publish b8d99fd45da58038d630d9855d3ca2466e8e0f89d
 You can observe the state machine in action locally by running:
 
 ```bash
-cargo stacks-node start --config=./testnet/stacks-node/conf/testnet-follower-conf.toml
+cargo stacks-node start --config ./testnet/stacks-node/conf/testnet-follower-conf.toml
 ```
 
 `testnet-follower-conf.toml` is a configuration file that you can use for setting genesis balances or configuring Event observers. You can grant an address an initial account balance by adding the following entries:

--- a/i18n/id/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
+++ b/i18n/id/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
@@ -109,7 +109,7 @@ Sekarang, ambil `privateKey` Anda dari sebelumnya, ketika Anda menjalankan perin
 Untuk menjalankan penambang Anda, jalankan ini di baris perintah:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 Noda Anda akan dimulai. Ini akan memakan waktu untuk menyinkronkan, dan kemudian penambang Anda akan berjalan.
@@ -127,7 +127,7 @@ Kode di atas akan mengkompilasi biner yang dioptimalkan. Untuk menggunakannya, j
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./mainnet-miner-conf.toml
+./target/release/stacks-node start --config ./mainnet-miner-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the mining guide](../understand-stacks/mining).
@@ -215,7 +215,7 @@ Sekarang, ambil `privateKey` Anda dari sebelumnya, ketika Anda menjalankan perin
 Untuk memulai penambang Anda, jalankan ini di baris perintah:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 :::note
@@ -231,7 +231,7 @@ Jika Anda mengalami masalah atau ingin melihat pencatatan verbose, Anda dapat me
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=mainnet-miner-conf.toml
+stacks-node start --config mainnet-miner-conf.toml
 ```
 
 ## Opsional: Berjalan dengan Docker

--- a/i18n/id/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
+++ b/i18n/id/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
@@ -105,7 +105,7 @@ Sekarang, ambil `privateKey` Anda dari sebelumnya, ketika Anda menjalankan perin
 Untuk menjalankan penambang Anda, jalankan ini di baris perintah:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 Noda Anda akan dimulai. Ini akan memakan waktu untuk menyinkronkan, dan kemudian penambang Anda akan berjalan.
@@ -123,7 +123,7 @@ Kode di atas akan mengkompilasi biner yang dioptimalkan. Untuk menggunakannya, j
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./testnet/conf/testnet-follower-conf.toml
+./target/release/stacks-node start --config ./testnet/conf/testnet-follower-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the minig guide](../understand-stacks/mining):
@@ -206,7 +206,7 @@ Sekarang, ambil `privateKey` Anda dari sebelumnya, ketika Anda menjalankan perin
 Untuk memulai penambang Anda, jalankan ini di baris perintah:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 <!-- markdown-link-check-disable -->
@@ -226,7 +226,7 @@ Jika Anda mengalami masalah atau ingin melihat pencatatan verbose, Anda dapat me
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=testnet-miner-conf.toml
+stacks-node start --config testnet-miner-conf.toml
 ```
 
 ## Opsional: Berjalan dengan Docker

--- a/i18n/id/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
+++ b/i18n/id/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
@@ -65,7 +65,7 @@ Memulai noda dengan konfigurasi Anda sendiri. Can be used for joining a network,
 Contoh:
 
 ```bash
-stacks-node start --config=/path/to/config.toml
+stacks-node start --config /path/to/config.toml
 ```
 
 Lihat [Opsi File Konfigurasi](#configuration-file-options) untuk informasi lebih lanjut.

--- a/i18n/ja/docusaurus-plugin-content-docs/current/blockchain/index.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/blockchain/index.md
@@ -102,7 +102,7 @@ cargo run --bin blockstack-cli publish b8d99fd45da58038d630d9855d3ca2466e8e0f89d
 You can observe the state machine in action locally by running:
 
 ```bash
-cargo stacks-node start --config=./testnet/stacks-node/conf/testnet-follower-conf.toml
+cargo stacks-node start --config ./testnet/stacks-node/conf/testnet-follower-conf.toml
 ```
 
 `testnet-follower-conf.toml` is a configuration file that you can use for setting genesis balances or configuring Event observers. You can grant an address an initial account balance by adding the following entries:

--- a/i18n/ja/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
@@ -109,7 +109,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -127,7 +127,7 @@ The above code will compile an optimized binary. To use it, run:
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./mainnet-miner-conf.toml
+./target/release/stacks-node start --config ./mainnet-miner-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the mining guide](../understand-stacks/mining).
@@ -215,7 +215,7 @@ Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` c
 To start your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 :::note
@@ -231,7 +231,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=mainnet-miner-conf.toml
+stacks-node start --config mainnet-miner-conf.toml
 ```
 
 ## Optional: Running with Docker

--- a/i18n/ja/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
@@ -105,7 +105,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -123,7 +123,7 @@ The above code will compile an optimized binary. To use it, run:
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./testnet/conf/testnet-follower-conf.toml
+./target/release/stacks-node start --config ./testnet/conf/testnet-follower-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the minig guide](../understand-stacks/mining):
@@ -206,7 +206,7 @@ Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` c
 To start your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 <!-- markdown-link-check-disable -->
@@ -226,7 +226,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=testnet-miner-conf.toml
+stacks-node start --config testnet-miner-conf.toml
 ```
 
 ## Optional: Running with Docker

--- a/i18n/ja/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
@@ -65,7 +65,7 @@ Start a node with a config of your own. Can be used for joining a network, start
 Example:
 
 ```bash
-stacks-node start --config=/path/to/config.toml
+stacks-node start --config /path/to/config.toml
 ```
 
 See [Configuration File Options](#configuration-file-options) for more information.

--- a/i18n/ko/docusaurus-plugin-content-docs/current/blockchain/index.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/blockchain/index.md
@@ -102,7 +102,7 @@ cargo run --bin blockstack-cli publish b8d99fd45da58038d630d9855d3ca2466e8e0f89d
 You can observe the state machine in action locally by running:
 
 ```bash
-cargo stacks-node start --config=./testnet/stacks-node/conf/testnet-follower-conf.toml
+cargo stacks-node start --config ./testnet/stacks-node/conf/testnet-follower-conf.toml
 ```
 
 `testnet-follower-conf.toml` is a configuration file that you can use for setting genesis balances or configuring Event observers. You can grant an address an initial account balance by adding the following entries:

--- a/i18n/ko/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
@@ -109,7 +109,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -127,7 +127,7 @@ The above code will compile an optimized binary. To use it, run:
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./mainnet-miner-conf.toml
+./target/release/stacks-node start --config ./mainnet-miner-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the mining guide](../understand-stacks/mining).
@@ -215,7 +215,7 @@ Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` c
 To start your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 :::note
@@ -231,7 +231,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=mainnet-miner-conf.toml
+stacks-node start --config mainnet-miner-conf.toml
 ```
 
 ## Optional: Running with Docker

--- a/i18n/ko/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
@@ -105,7 +105,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -123,7 +123,7 @@ The above code will compile an optimized binary. To use it, run:
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./testnet/conf/testnet-follower-conf.toml
+./target/release/stacks-node start --config ./testnet/conf/testnet-follower-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the minig guide](../understand-stacks/mining):
@@ -206,7 +206,7 @@ Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` c
 To start your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 <!-- markdown-link-check-disable -->
@@ -226,7 +226,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=testnet-miner-conf.toml
+stacks-node start --config testnet-miner-conf.toml
 ```
 
 ## Optional: Running with Docker

--- a/i18n/ko/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
@@ -65,7 +65,7 @@ Start a node with a config of your own. Can be used for joining a network, start
 Example:
 
 ```bash
-stacks-node start --config=/path/to/config.toml
+stacks-node start --config /path/to/config.toml
 ```
 
 See [Configuration File Options](#configuration-file-options) for more information.

--- a/i18n/pt/docusaurus-plugin-content-docs/current/blockchain/index.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/current/blockchain/index.md
@@ -102,7 +102,7 @@ cargo run --bin blockstack-cli publish b8d99fd45da58038d630d9855d3ca2466e8e0f89d
 You can observe the state machine in action locally by running:
 
 ```bash
-cargo stacks-node start --config=./testnet/stacks-node/conf/testnet-follower-conf.toml
+cargo stacks-node start --config ./testnet/stacks-node/conf/testnet-follower-conf.toml
 ```
 
 `testnet-follower-conf.toml` is a configuration file that you can use for setting genesis balances or configuring Event observers. You can grant an address an initial account balance by adding the following entries:

--- a/i18n/pt/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
@@ -109,7 +109,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -127,7 +127,7 @@ The above code will compile an optimized binary. To use it, run:
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./mainnet-miner-conf.toml
+./target/release/stacks-node start --config ./mainnet-miner-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the mining guide](../understand-stacks/mining).
@@ -215,7 +215,7 @@ Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` c
 To start your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 :::note While starting the node for the first time, windows defender might pop up with a message to allow access. If so, allow access to run the node.
@@ -230,7 +230,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=mainnet-miner-conf.toml
+stacks-node start --config mainnet-miner-conf.toml
 ```
 
 ## Optional: Running with Docker

--- a/i18n/pt/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
@@ -105,7 +105,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -123,7 +123,7 @@ The above code will compile an optimized binary. To use it, run:
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./testnet/conf/testnet-follower-conf.toml
+./target/release/stacks-node start --config ./testnet/conf/testnet-follower-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the minig guide](../understand-stacks/mining):
@@ -206,7 +206,7 @@ Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` c
 To start your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 <!-- markdown-link-check-disable -->
@@ -225,7 +225,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=testnet-miner-conf.toml
+stacks-node start --config testnet-miner-conf.toml
 ```
 
 ## Optional: Running with Docker

--- a/i18n/pt/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
@@ -65,7 +65,7 @@ Start a node with a config of your own. Can be used for joining a network, start
 Example:
 
 ```bash
-stacks-node start --config=/path/to/config.toml
+stacks-node start --config /path/to/config.toml
 ```
 
 See [Configuration File Options](#configuration-file-options) for more information.

--- a/i18n/ru/docusaurus-plugin-content-docs/current/blockchain/index.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/blockchain/index.md
@@ -102,7 +102,7 @@ cargo run --bin blockstack-cli publish b8d99fd45da58038d630d9855d3ca2466e8e0f89d
 You can observe the state machine in action locally by running:
 
 ```bash
-cargo stacks-node start --config=./testnet/stacks-node/conf/testnet-follower-conf.toml
+cargo stacks-node start --config ./testnet/stacks-node/conf/testnet-follower-conf.toml
 ```
 
 `testnet-follower-conf.toml` is a configuration file that you can use for setting genesis balances or configuring Event observers. You can grant an address an initial account balance by adding the following entries:

--- a/i18n/ru/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
@@ -109,7 +109,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -127,7 +127,7 @@ The above code will compile an optimized binary. To use it, run:
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./mainnet-miner-conf.toml
+./target/release/stacks-node start --config ./mainnet-miner-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the mining guide](../understand-stacks/mining).
@@ -215,7 +215,7 @@ Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` c
 To start your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 :::note
@@ -231,7 +231,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=mainnet-miner-conf.toml
+stacks-node start --config mainnet-miner-conf.toml
 ```
 
 ## Optional: Running with Docker

--- a/i18n/ru/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
@@ -105,7 +105,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -123,7 +123,7 @@ The above code will compile an optimized binary. To use it, run:
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./testnet/conf/testnet-follower-conf.toml
+./target/release/stacks-node start --config ./testnet/conf/testnet-follower-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the minig guide](../understand-stacks/mining):
@@ -206,7 +206,7 @@ Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` c
 To start your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 <!-- markdown-link-check-disable -->
@@ -226,7 +226,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=testnet-miner-conf.toml
+stacks-node start --config testnet-miner-conf.toml
 ```
 
 ## Optional: Running with Docker

--- a/i18n/ru/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
@@ -65,7 +65,7 @@ Start a node with a config of your own. Can be used for joining a network, start
 Example:
 
 ```bash
-stacks-node start --config=/path/to/config.toml
+stacks-node start --config /path/to/config.toml
 ```
 
 See [Configuration File Options](#configuration-file-options) for more information.

--- a/i18n/tr/docusaurus-plugin-content-docs/current/blockchain/index.md
+++ b/i18n/tr/docusaurus-plugin-content-docs/current/blockchain/index.md
@@ -102,7 +102,7 @@ cargo run --bin blockstack-cli publish b8d99fd45da58038d630d9855d3ca2466e8e0f89d
 You can observe the state machine in action locally by running:
 
 ```bash
-cargo stacks-node start --config=./testnet/stacks-node/conf/testnet-follower-conf.toml
+cargo stacks-node start --config ./testnet/stacks-node/conf/testnet-follower-conf.toml
 ```
 
 `testnet-follower-conf.toml` is a configuration file that you can use for setting genesis balances or configuring Event observers. You can grant an address an initial account balance by adding the following entries:

--- a/i18n/tr/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
+++ b/i18n/tr/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
@@ -109,7 +109,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -127,7 +127,7 @@ The above code will compile an optimized binary. To use it, run:
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./mainnet-miner-conf.toml
+./target/release/stacks-node start --config ./mainnet-miner-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the mining guide](../understand-stacks/mining).
@@ -215,7 +215,7 @@ Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` c
 To start your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 :::note
@@ -231,7 +231,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=mainnet-miner-conf.toml
+stacks-node start --config mainnet-miner-conf.toml
 ```
 
 ## Optional: Running with Docker

--- a/i18n/tr/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
+++ b/i18n/tr/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
@@ -105,7 +105,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -123,7 +123,7 @@ The above code will compile an optimized binary. To use it, run:
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./testnet/conf/testnet-follower-conf.toml
+./target/release/stacks-node start --config ./testnet/conf/testnet-follower-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the minig guide](../understand-stacks/mining):
@@ -206,7 +206,7 @@ Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` c
 To start your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 <!-- markdown-link-check-disable -->
@@ -226,7 +226,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=testnet-miner-conf.toml
+stacks-node start --config testnet-miner-conf.toml
 ```
 
 ## Optional: Running with Docker

--- a/i18n/tr/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
+++ b/i18n/tr/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
@@ -65,7 +65,7 @@ Start a node with a config of your own. Can be used for joining a network, start
 Example:
 
 ```bash
-stacks-node start --config=/path/to/config.toml
+stacks-node start --config /path/to/config.toml
 ```
 
 See [Configuration File Options](#configuration-file-options) for more information.

--- a/i18n/vi/docusaurus-plugin-content-docs/current/blockchain/index.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/blockchain/index.md
@@ -102,7 +102,7 @@ cargo run --bin blockstack-cli publish b8d99fd45da58038d630d9855d3ca2466e8e0f89d
 You can observe the state machine in action locally by running:
 
 ```bash
-cargo stacks-node start --config=./testnet/stacks-node/conf/testnet-follower-conf.toml
+cargo stacks-node start --config ./testnet/stacks-node/conf/testnet-follower-conf.toml
 ```
 
 `testnet-follower-conf.toml` is a configuration file that you can use for setting genesis balances or configuring Event observers. You can grant an address an initial account balance by adding the following entries:

--- a/i18n/vi/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
@@ -109,7 +109,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -127,7 +127,7 @@ The above code will compile an optimized binary. To use it, run:
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./mainnet-miner-conf.toml
+./target/release/stacks-node start --config ./mainnet-miner-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the mining guide](../understand-stacks/mining).
@@ -215,7 +215,7 @@ Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` c
 To start your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 :::note
@@ -231,7 +231,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=mainnet-miner-conf.toml
+stacks-node start --config mainnet-miner-conf.toml
 ```
 
 ## Optional: Running with Docker

--- a/i18n/vi/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
@@ -105,7 +105,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -123,7 +123,7 @@ The above code will compile an optimized binary. To use it, run:
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./testnet/conf/testnet-follower-conf.toml
+./target/release/stacks-node start --config ./testnet/conf/testnet-follower-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the minig guide](../understand-stacks/mining):
@@ -206,7 +206,7 @@ Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` c
 To start your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 <!-- markdown-link-check-disable -->
@@ -226,7 +226,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=testnet-miner-conf.toml
+stacks-node start --config testnet-miner-conf.toml
 ```
 
 ## Optional: Running with Docker

--- a/i18n/vi/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
@@ -65,7 +65,7 @@ Start a node with a config of your own. Can be used for joining a network, start
 Example:
 
 ```bash
-stacks-node start --config=/path/to/config.toml
+stacks-node start --config /path/to/config.toml
 ```
 
 See [Configuration File Options](#configuration-file-options) for more information.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/blockchain/index.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/blockchain/index.md
@@ -102,7 +102,7 @@ cargo run --bin blockstack-cli publish b8d99fd45da58038d630d9855d3ca2466e8e0f89d
 You can observe the state machine in action locally by running:
 
 ```bash
-cargo stacks-node start --config=./testnet/stacks-node/conf/testnet-follower-conf.toml
+cargo stacks-node start --config ./testnet/stacks-node/conf/testnet-follower-conf.toml
 ```
 
 `testnet-follower-conf.toml` is a configuration file that you can use for setting genesis balances or configuring Event observers. You can grant an address an initial account balance by adding the following entries:

--- a/i18n/zh/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-mainnet.md
@@ -138,7 +138,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 Your node should start. Your node should start. Your node should start. It will take some time to sync, and then your miner will be running.
@@ -158,7 +158,7 @@ The above code will compile an optimized binary. To use it, run: To use it, run:
 cd ../..
 cd ../..
 cd ../..
-./target/release/stacks-node start --config=./mainnet-miner-conf.toml
+./target/release/stacks-node start --config ./mainnet-miner-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the mining guide](../understand-stacks/mining).
@@ -275,13 +275,13 @@ Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` c
 To start your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/mainnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/mainnet-miner-conf.toml
 ```
 
 :::note
 While starting the node for the first time, windows defender might pop up with a message to allow access. If so, allow access to run the node.
-:::  If so, allow access to run the node.
-:::  If so, allow access to run the node.
+::: If so, allow access to run the node.
+::: If so, allow access to run the node.
 ::: ![Windows Defender](/img/windows-defender.png)
 
 Your node should start. Your node should start. It will take some time to sync, and then your miner will be running.
@@ -293,7 +293,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=mainnet-miner-conf.toml
+stacks-node start --config mainnet-miner-conf.toml
 ```
 
 ## Optional: Running with Docker

--- a/i18n/zh/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/nodes-and-miners/miner-testnet.md
@@ -132,7 +132,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config ./testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 Your node should start. Your node should start. It will take some time to sync, and then your miner will be running.
@@ -152,7 +152,7 @@ The above code will compile an optimized binary. To use it, run: To use it, run:
 cd ../..
 cd ../..
 cd ../..
-./target/release/stacks-node start --config=./testnet/conf/testnet-follower-conf.toml
+./target/release/stacks-node start --config ./testnet/conf/testnet-follower-conf.toml
 ```
 
 To read more about the technical details of mining on the Stacks 2.0 network, have a look at [the minig guide](../understand-stacks/mining):
@@ -262,14 +262,14 @@ Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` c
 To start your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config testnet/stacks-node/conf/testnet-miner-conf.toml
 ```
 
 <!-- markdown-link-check-disable -->
 
 :::note
 While starting the node for the first time, windows defender might pop up with a message to allow access. If so, allow access to run the node.
-:::  If so, allow access to run the node.
+::: If so, allow access to run the node.
 ::: ![Windows Defender](/img/windows-defender.png)
 
 <!-- markdown-link-check-enable-->
@@ -283,7 +283,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 ```bash
 set RUST_BACKTRACE=full;
 set STACKS_LOG_DEBUG=1;
-stacks-node start --config=testnet-miner-conf.toml
+stacks-node start --config testnet-miner-conf.toml
 ```
 
 ## Optional: Running with Docker

--- a/i18n/zh/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/nodes-and-miners/stacks-node-configuration.md
@@ -65,7 +65,7 @@ Start a node with a config of your own. Start a node with a config of your own. 
 Example:
 
 ```bash
-stacks-node start --config=/path/to/config.toml
+stacks-node start --config /path/to/config.toml
 ```
 
 See [Configuration File Options](#configuration-file-options) for more information.


### PR DESCRIPTION
for upcoming release 2.4.0.0.5, the command-line args have been changed slightly. 
previously, this is how you would start a node with a static config:
```bash
stacks-node start --config=/path/to/config.toml
```

and the new args (once 2.4.0.0.5 is release):
```bash
stacks-node start --config /path/to/config.toml
```
*note the `=` has been removed in the `--config` arg*

## This is only to be merged *AFTER* stacks-core 2.4.0.0.5 is released