### PR TITLE
Removing equals from --config (pico-args upstream update)

### DIFF
--- a/stacks-in-depth/nodes-and-miners/mine-testnet-stacks-tokens.md
+++ b/stacks-in-depth/nodes-and-miners/mine-testnet-stacks-tokens.md
@@ -172,7 +172,7 @@ amount = 10000000000000000
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=$HOME/testnet-miner-conf.toml
+stacks-node start --config $HOME/testnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -182,7 +182,7 @@ Your node should start. It will take some time to sync, and then your miner will
 In case you are running into issues or would like to see verbose logging, you can run your node with debug logging enabled. In the command line, run:
 
 ```bash
-STACKS_LOG_DEBUG=1 stacks-node start --config=$HOME/testnet-miner-conf.toml
+STACKS_LOG_DEBUG=1 stacks-node start --config $HOME/testnet-miner-conf.toml
 ```
 
 ***


### PR DESCRIPTION
`2.4.0.1.0` had an upstream dependency update that requires a small change to running stacks-node with the `--config` arg:
previously: `stacks-node --config=/path/to/Config.toml` was valid. 

with the update, the above no longer works and must be: `stacks-node --config /path/to/Config.toml`

note the missing `=` 