### PR TITLE
Fix Typo in Miner Docs

### DIFF
--- a/stacks-in-depth/nodes-and-miners/mine-mainnet-stacks-tokens.md
+++ b/stacks-in-depth/nodes-and-miners/mine-mainnet-stacks-tokens.md
@@ -196,7 +196,7 @@ burn_fee_cap = 20000
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=$HOME/mainnet-miner-conf.toml
+stacks-node start --config $HOME/mainnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -206,7 +206,7 @@ Your node should start. It will take some time to sync, and then your miner will
 In case you are running into issues or would like to see verbose logging, you can run your node with debug logging enabled. In the command line, run:
 
 ```bash
-STACKS_LOG_DEBUG=1 stacks-node start --config=$HOME/mainnet-miner-conf.toml
+STACKS_LOG_DEBUG=1 stacks-node start --config $HOME/mainnet-miner-conf.toml
 ```
 
 ***


### PR DESCRIPTION
## Description

Fix typo in mainnet miner config option (change `=` to space).