### PR TITLE
Update storage reqs to 350GB and other fixes

### DIFF
--- a/nakamoto-upgrade/signing-and-stacking/running-a-signer.md
+++ b/nakamoto-upgrade/signing-and-stacking/running-a-signer.md
@@ -113,7 +113,7 @@ Note that at the moment the signer should only be run on testnet using these ins
 
 #### Running the Signer with Docker
 
-You can run the signer as a Docker container using the [`blockstack/stacks-core:2.5.0.0.0-rc5`](https://hub.docker.com/layers/blockstack/stacks-core/2.5.0.0.0-rc5/images/sha256-5e8df14356c2e5dc9500dea0a210c9135f1f0347072a2658fbd737a81638e831?context=explore) image. When pulling the Docker image, be sure you are using the `2.5.0.0.0-rc5` tag, as the main branch will not have the signer binary.
+You can run the signer as a Docker container using the [`blockstack/stacks-core:2.5.0.0.2`](https://hub.docker.com/layers/blockstack/stacks-core/2.5.0.0.2/images/sha256-ed20a145a8cfb6ec8a7e6f0c7d3ea25b55747b147d2cf080cbc0609ee77deb30?context=explore) image. When pulling the Docker image, be sure you are using the `2.5.0.0.2` tag, as the main branch will not have the signer binary.
 
 When running the Docker container, you’ll need to ensure a few things:
 
@@ -127,7 +127,7 @@ Be sure to replace the `STX_SIGNER_PATH` with the correct path to your config fi
 
 ```bash
 IMG="blockstack/stacks-core"
-VER="2.5.0.0.0-rc5"
+VER="2.5.0.0.2"
 STX_SIGNER_PATH="./"
 STX_SIGNER_DATA="$STX_SIGNER_PATH/data"
 STX_SIGNER_CONFIG="$STX_SIGNER_PATH/signer-config.toml"
@@ -152,7 +152,7 @@ For example, if you are running on M1 Mac, you would add `--platform=linux/amd64
 Or, with a custom Dockerfile:
 
 ```docker
-FROM blockstack/stacks-core:2.5.0.0.0-rc5
+FROM blockstack/stacks-core:2.5.0.0.2
 COPY signer-config.toml /config.toml
 EXPOSE 30000
 CMD ["stacks-signer", "run", "--config", "/config.toml"]
@@ -224,12 +224,12 @@ The important aspects that you’ll need to change are:
 
 If you are running your Stacks node on the primary testnet, it will be much faster to start with an archive of the chain state rather than syncing from genesis.
 
-Archives can be found from [https://archive.hiro.so](https://archive.hiro.so). For the Stacks node testnet, the latest snapshot can be found at [https://archive.hiro.so/testnet/stacks-blockchain/testnet-stacks-blockchain-2.5.0.0.0-rc5-latest.tar.gz](https://archive.hiro.so/testnet/stacks-blockchain/testnet-stacks-blockchain-2.5.0.0.0-rc5-latest.tar.gz). Note that the version is specified (2.5.0.0.0-rc5). When we update versions (ie to a new RC), that URL will need to change. You can also [browse all testnet snapshots](https://archive.hiro.so/testnet/stacks-blockchain/).
+Archives can be found from [https://archive.hiro.so](https://archive.hiro.so). For the Stacks node testnet, the latest snapshot can be found at [https://archive.hiro.so/testnet/stacks-blockchain/testnet-stacks-blockchain-2.5.0.0.2-latest.tar.gz](https://archive.hiro.so/testnet/stacks-blockchain/testnet-stacks-blockchain-2.5.0.0.2-latest.tar.gz). Note that the version is specified (2.5.0.0.2). When we update versions (ie to a new RC), that URL will need to change. You can also [browse all testnet snapshots](https://archive.hiro.so/testnet/stacks-blockchain/).
 
 You’ll want to download this on the same machine that will run the Stacks node. One way to do this is:
 
 ```
-curl https://archive.hiro.so/testnet/stacks-blockchain/testnet-stacks-blockchain-2.5.0.0.0-rc5-latest.tar.gz -o stacks-snapshot.tar.gz
+curl -# https://archive.hiro.so/testnet/stacks-blockchain/testnet-stacks-blockchain-2.5.0.0.2-latest.tar.gz -o stacks-snapshot.tar.gz
 tar -zxvf stacks-snapshot.tar.gz
 ```
 
@@ -256,7 +256,7 @@ An example for running the node’s Docker image with docker run is below. Be su
 
 ```bash
 IMG="blockstack/stacks-core"
-VER="2.5.0.0.0-rc5"
+VER="2.5.0.0.2"
 STX_NODE_CONFIG="./node-config.toml"
 
 docker run -d \
@@ -273,7 +273,7 @@ docker run -d \
 Or, using a custom Dockerfile:
 
 ```docker
-FROM blockstack/stacks-core:2.5.0.0.0-rc5
+FROM blockstack/stacks-core:2.5.0.0.2
 COPY node-config.toml /config.toml
 EXPOSE 20444
 EXPOSE 20443

--- a/nakamoto-upgrade/signing-and-stacking/running-a-signer.md
+++ b/nakamoto-upgrade/signing-and-stacking/running-a-signer.md
@@ -4,7 +4,7 @@
 
 * 8 vcpu
 * 32GB memory
-* 1 TB storage for Bitcoin node, 250 GB for Stacks node, and 1 GB for signer
+* 1 TB storage for Bitcoin node, 350 GB for Stacks node, and 1 GB for signer
 
 ### Background and High-Level Process
 
@@ -31,7 +31,7 @@ Detailed steps for each of these are laid out below, but this checklist is being
 * [ ] Ensure your system meets the following requirements:
   * 4 vCPU
   * 8GB memory
-  * 150 GB storage (250 GB if running a Stacks node)
+  * 150 GB storage (350 GB if running a Stacks node)
 * [ ] Acquire Docker and basic knowledge of Stacks accounts, stacking, and the Nakamoto stacking flow (links provided below).
 
 #### Preflight Setup

--- a/nakamoto-upgrade/signing-and-stacking/stacking-flow.md
+++ b/nakamoto-upgrade/signing-and-stacking/stacking-flow.md
@@ -728,10 +728,6 @@ stacks-signer generate-stacking-signature \
   --topic stack-stx
 ```
 
-{% hint style="warning" %}
-There is a known bug in release \`2.5.0.0.0-rc1\` that will throw an error if using a P2PKH address. This will be fixed in the next release. If you run into an error like the below, we recommend using either stacks.js or Lockstacks to generate your signature as outlined below.
-{% endhint %}
-
 These arguments are:
 
 * pox-address: the BTC address where the signer wants to receive Stacking rewards

--- a/stacks-in-depth/nodes-and-miners/run-a-node-with-docker.md
+++ b/stacks-in-depth/nodes-and-miners/run-a-node-with-docker.md
@@ -20,7 +20,7 @@ While you _can_ run a node using these specs, it's _recommended_ to assign more 
 * ⚠️ [docker-compose](https://docs.docker.com/compose/install/) version `2.2.2` or greater is **required**
 * **4GB memory**
 * **1 Vcpu** ( _minimum of 2 Vcpu is recommended_ )
-* **250GB disk**
+* **350GB disk**
 
 {% hint style="warning" %}
 MacOS with an ARM processor is NOT recommended


### PR DESCRIPTION
In testing, 250GB *is ok* - but on a Debian server based system (i.e. not a lot of extra packages installed), the chainstate + the os takes around 220GB. 

the chainstate itself is around 190GB today. 

updating to 350GB should be considered the new minimum for 6-12 months of chain growth. 