### PR TITLE
fix: docs to `generate-stacking-signature`

### DIFF
--- a/nakamoto-upgrade/signing-and-stacking/stacking-flow.md
+++ b/nakamoto-upgrade/signing-and-stacking/stacking-flow.md
@@ -725,30 +725,34 @@ The CLI command is:
 
 ```bash
 stacks-signer generate-stacking-signature \
-  --pox-address bc1... \
-  --reward-cycle 100 \
-  --config ./config.toml \
+  --method stack-stx \
+  --max-amount 1000000000000 \
+  --auth-id 195591226970828652622091037492597751808 \
   --period 1 \
-  --topic stack-stx
+  --reward-cycle 100 \
+  --pox-address bc1... \
+  --config ./config.toml \
+  --json
 ```
 
-These arguments are:
+These arguments match those described in section [Overview of signer keys and signatures](#overview-of-signer-keys-and-signatures), with the addition of:
 
-* pox-address: the BTC address where the signer wants to receive Stacking rewards
-* reward-cycle: For solo stacking, this must refer to the current reward cycle where the user will broadcast their Stacking transaction. For the stack-aggregation-commit transaction, used in delegated signing, this should match the reward-cycle they are using as an argument in stack-aggregation-commit.
-* config: path to a local Signer configuration file
-* period: for solo stacking, this refers to the lock-period argument the user makes in stack-stx and the extend-count argument in stack-extend. **For stack-aggregation-commit, this must equal 1**.
-* topic: This string is dependent on the Stacking function where the signature will be used.
-  * For stack-stx, the topic needs to be `stack-stx`
-  * For stack-extend, the topic needs to be `stack-extend`
-  * For stack-aggregation-commit, the topic needs to be `agg-commit`
+* `--config`, to provide the configuration file path;
+* `--json`, to optionally output the resulting signature in JSON.
 
-Once the command is run, the CLI will output two fields:
+You can use the following command to generate a random `128` bits `auth-id`:
 
-* Signature: 0xaaaaaaaaa
-* Public Key: 0xbbbbbb
+```bash
+openssl rand -hex 16 | awk '{ print strtonum("0x"$0) }'
+```
 
-You will use both the signature and public key when calling Stacking transactions from your pool operator address as outlined above. Remember that this may be different than your signer address.
+Once the `generate-stacking-signature` command is run, the CLI will output a JSON:
+
+```json
+{"authId":"1234","maxAmount":"1234","method":"stack-stx","period":1,"poxAddress":"bc1...","rewardCycle":100,"signerKey":"aaaaaaaa","signerSignature":"bbbbbbbbbbb"}
+```
+
+You will use the JSON when calling Stacking transactions from your pool operator address as outlined above. Remember that this may be different than your signer address.
 
 #### Generating your signature with Lockstacks
 

--- a/nakamoto-upgrade/signing-and-stacking/stacking-flow.md
+++ b/nakamoto-upgrade/signing-and-stacking/stacking-flow.md
@@ -743,7 +743,7 @@ These arguments match those described in section [Overview of signer keys and si
 You can use the following command to generate a random `128` bit integer as `auth-id`:
 
 ```bash
-openssl rand -hex 16 | awk '{ print strtonum("0x"$0) }'
+python3 -c 'import secrets; print(secrets.randbits(128))'
 ```
 
 Once the `generate-stacking-signature` command is run, the CLI will output a JSON:

--- a/nakamoto-upgrade/signing-and-stacking/stacking-flow.md
+++ b/nakamoto-upgrade/signing-and-stacking/stacking-flow.md
@@ -740,7 +740,7 @@ These arguments match those described in section [Overview of signer keys and si
 * `--config`, to provide the configuration file path;
 * `--json`, to optionally output the resulting signature in JSON.
 
-You can use the following command to generate a random `128` bits `auth-id`:
+You can use the following command to generate a random `128` bit integer as `auth-id`:
 
 ```bash
 openssl rand -hex 16 | awk '{ print strtonum("0x"$0) }'


### PR DESCRIPTION
## Description

Trying to follow the docs to generate a new signer signature through the CLI was failing because of mismatched CLI parameters (in the docs and in the executable).

This PR fixes that, by changing changes `topic` to `method` and adds the missing cli arguments for:

--max-amount <MAX_AMOUNT>
--auth-id <AUTH_ID>

To keep things DRY, I have removed the repetition of the parameters description and just referenced the appropriate section.

Lastly, I added the `--json` flag, since it makes it easier to provide the generated signature to lockstacks.