### PR TITLE
fix: add `stacker = true` to configs

### DIFF
--- a/nakamoto-upgrade/signing-and-stacking/sample-configuration-files.md
+++ b/nakamoto-upgrade/signing-and-stacking/sample-configuration-files.md
@@ -56,6 +56,8 @@ p2p_bind = "0.0.0.0:20444"
 bootstrap_node = "0341b2ff35b545d8e5c5d2fc8821484610ef85ce8e276214caf23d53be16fdcd65@seed.nakamoto.testnet.hiro.so:50444"
 wait_time_for_microblocks = 0
 mine_microblocks = false
+# Required for nodes attached to signers, optional for other nodes
+stacker = true
 
 [burnchain]
 chain = "bitcoin"
@@ -264,6 +266,8 @@ bootstrap_node = "029266faff4c8e0ca4f934f34996a96af481df94a89b0c9bd515f3536a9568
 prometheus_bind = "0.0.0.0:9153"
 working_dir = "/hirosystems/data"
 local_peer_seed = "{{ redacted }}"
+# Required for nodes attached to signers, optional for other nodes
+stacker = true
 
 [burnchain]
 chain = "bitcoin"
@@ -391,6 +395,7 @@ rpc_bind = "0.0.0.0:20443"
 p2p_bind = "0.0.0.0:20444"
 # This is the node that your node will use to begin syncing chain state
 bootstrap_node = "02196f005965cebe6ddc3901b7b1cc1aa7a88f305bb8c5893456b8f9a605923893@seed.mainnet.hiro.so:20444,02539449ad94e6e6392d8c1deb2b4e61f80ae2a18964349bc14336d8b903c46a8c@cet.stacksnodes.org:20444,02ececc8ce79b8adf813f13a0255f8ae58d4357309ba0cedd523d9f1a306fcfb79@sgt.stacksnodes.org:20444,0303144ba518fe7a0fb56a8a7d488f950307a4330f146e1e1458fc63fb33defe96@est.stacksnodes.org:20444"
+# Required for nodes attached to signers, optional for other nodes
 stacker = true
 
 [burnchain]


### PR DESCRIPTION
## Description

This `stacker = true` is required for nodes attached to stackers. It was mentioned in one paragraph, but it should be in the sample configs to ensure it is not missed.