### PR TITLE
fix: nodes with signers require `stacker = true`

### DIFF
--- a/nakamoto-upgrade/nakamoto-activation-guide-for-signers/setting-up-a-primary-post-nakamoto-testnet-node.md
+++ b/nakamoto-upgrade/nakamoto-activation-guide-for-signers/setting-up-a-primary-post-nakamoto-testnet-node.md
@@ -34,6 +34,7 @@ rpc_bind = "0.0.0.0:20443"
 p2p_bind = "0.0.0.0:20444"
 bootstrap_node = "029266faff4c8e0ca4f934f34996a96af481df94a89b0c9bd515f3536a95682ddc@seed.testnet.hiro.so:30444"
 prometheus_bind = "0.0.0.0:9153"
+stacker = true
 
 [burnchain]
 chain = "bitcoin"
@@ -75,7 +76,7 @@ amount = 10000000000000000
 
 [fee_estimation]
 fee_estimator = "fuzzed_weighted_median_fee_rate"
-    
+
 [[burnchain.epochs]]
 epoch_name = "1.0"
 start_height = 0
@@ -180,7 +181,7 @@ amount = 10000000000000000
 
 [fee_estimation]
 fee_estimator = "fuzzed_weighted_median_fee_rate"
-    
+
 [[burnchain.epochs]]
 epoch_name = "1.0"
 start_height = 0


### PR DESCRIPTION
## Description

As specified in `sample-configuration-file`, nodes having a signer attached need to set `stacker = true`. Internally, this configures the node to appropriately keep track of required events (https://github.com/stacks-network/stacks-core/blob/9db16f6ec61598e9293eced2ca9371c84a49b0f8/testnet/stacks-node/src/config.rs#L2165).

Thanks @obycode for confirming that `stacker = true` is required.