### PR TITLE
Update Signer and Node Versions

### DIFF
--- a/guides-and-tutorials/running-a-signer/README.md
+++ b/guides-and-tutorials/running-a-signer/README.md
@@ -12,7 +12,7 @@ Binaries will be provided roughly a week in advance and your normal upgrade proc
 For quick reference, here are the current latest versions you'll want to be running as a signer. If you don't yet have your signer up and running, this guide will walk you through that.
 
 * Signer - [2.5.0.0.5.2](https://hub.docker.com/layers/blockstack/stacks-signer/2.5.0.0.5.2/images/sha256-fc29a7c22f236f91270fb1aa58cfb4dd8dcd6b1daa0812e16df0bdc7643cb6ac?context=explore)
-* Stacks Node - [2.5.0.0.6](https://hub.docker.com/layers/blockstack/stacks-core/2.5.0.0.6/images/sha256-f6f17cd1399c5c4739ae34f7fc313775378f0bcbc5a985f0d7d02d008b5e9631?context=explore)
+* Stacks Node - [2.5.0.0.7](https://hub.docker.com/layers/blockstack/stacks-core/2.5.0.0.7/images/sha256-71d3eb305b5c1b68cd44904a7bcd6e5f92542135a7218762cdf27a46acaff69b?context=explore)
 {% endhint %}
 
 ### How to Use This Guide
@@ -279,7 +279,7 @@ For example:
 
 #### Run a Stacks Node with Docker
 
-You can run the Stacks node as a Docker container using the `blockstack/stacks-core` image, currently on [version 2.5.0.0.6](https://hub.docker.com/layers/blockstack/stacks-core/2.5.0.0.6/images/sha256-f6f17cd1399c5c4739ae34f7fc313775378f0bcbc5a985f0d7d02d008b5e9631?context=explore). When running the Docker container, you’ll need to ensure a few things:
+You can run the Stacks node as a Docker container using the `blockstack/stacks-core` image, currently on [version 2.5.0.0.7](https://hub.docker.com/layers/blockstack/stacks-core/2.5.0.0.7/images/sha256-71d3eb305b5c1b68cd44904a7bcd6e5f92542135a7218762cdf27a46acaff69b?context=explore). When running the Docker container, you’ll need to ensure a few things:
 
 * The port configured for `p2p_bind` must be exposed to the internet
 * The port configured for `rpc_bind` must be accessible by your signer
@@ -290,7 +290,7 @@ An example for running the node’s Docker image with docker run is below. Be su
 
 ```bash
 IMG="blockstack/stacks-core"
-VER="2.5.0.0.6"
+VER="2.5.0.0.7"
 STX_NODE_CONFIG="./node-config.toml"
 
 docker run -d \
@@ -308,7 +308,7 @@ docker run -d \
 Or, using a custom Dockerfile:
 
 ```docker
-FROM blockstack/stacks-core:2.5.0.0.6
+FROM blockstack/stacks-core:2.5.0.0.7
 COPY node-config.toml /config.toml
 EXPOSE 20444
 EXPOSE 20443

--- a/nakamoto-upgrade/nakamoto-activation-guide-for-signers/README.md
+++ b/nakamoto-upgrade/nakamoto-activation-guide-for-signers/README.md
@@ -12,8 +12,8 @@ This initial phase focuses on testing Signer 3.0 readiness in a testnet environm
 
 **Action Required:**
 
-1. Update stacks-node to version 2.5.0.0.6 ([here](https://github.com/stacks-network/stacks-core/releases/tag/2.5.0.0.6))
-2. Update signer to version 2.5.0.0.5.2-rc1 ([here](https://github.com/stacks-network/stacks-core/releases/tag/signer-2.5.0.0.5.2-rc1))
+1. Update stacks-node to version 2.5.0.0.7 ([here](https://github.com/stacks-network/stacks-core/releases/tag/2.5.0.0.7))
+2. Update signer to version 2.5.0.0.5.2 ([here](https://github.com/stacks-network/stacks-core/releases/tag/signer-2.5.0.0.5.2))
 3. [Run a Primary Testnet node](setting-up-a-primary-post-nakamoto-testnet-node.md) alongside your Signer
 4. Create a testnet wallet address
 5. Complete the provided form ([here](https://blocksurvey.io/signer-nakamoto-activation-upgrade-GrOV5aivQ2.z2fh3bqEyLQ?v=o))

--- a/nakamoto-upgrade/nakamoto-activation-guide-for-signers/setting-up-a-primary-post-nakamoto-testnet-node.md
+++ b/nakamoto-upgrade/nakamoto-activation-guide-for-signers/setting-up-a-primary-post-nakamoto-testnet-node.md
@@ -2,7 +2,7 @@
 
 ### **Setup A Stacks Primary Testnet Node**
 
-Once your signer is upgraded to version 2.5.0.0.5.2-rc1 ([here](https://github.com/stacks-network/stacks-core/releases/tag/signer-2.5.0.0.5.2-rc1)) you’ll need to run a primary testnet node alongside it.
+Once your signer is upgraded to version 2.5.0.0.5.2 ([here](https://github.com/stacks-network/stacks-core/releases/tag/signer-2.5.0.0.5.2)) you’ll need to run a primary testnet node alongside it.
 
 You have two options here. The first is to run the Bash script below and it will handle everything for you, including creating the configuration file, downloading and extracting a chain state archive, and getting the node up and running.
 
@@ -20,7 +20,7 @@ STACKS_RPC_PORT="40443"
 STACKS_P2P_PORT="40444"
 
 IMG="blockstack/stacks-core"
-VER="2.5.0.0.6"
+VER="2.5.0.0.7"
 STX_NODE_CONFIG="${STACKS_DIR}/Config.toml"
 
 mkdir -p ${STACKS_DIR}/data
@@ -251,7 +251,7 @@ An example for running the node’s Docker image with docker run is below. Be su
 ```bash
 IMG="blockstack/stacks-core"
 
-VER="2.5.0.0.6"
+VER="2.5.0.0.7"
 
 STX_NODE_CONFIG="./node-config.toml"
 
@@ -270,7 +270,7 @@ stacks-node start \\
 Or, using a custom Dockerfile:
 
 ```docker
-FROM blockstack/stacks-core:2.5.0.0.6
+FROM blockstack/stacks-core:2.5.0.0.7
 COPY node-config.toml /config.toml
 EXPOSE 20444
 EXPOSE 20443

--- a/reference/sample-configuration-files.md
+++ b/reference/sample-configuration-files.md
@@ -11,7 +11,7 @@ Binaries will be provided roughly a week in advance and your normal upgrade proc
 If you are a signer, these are the current latest versions you'll want to be running.
 
 * Signer - [2.5.0.0.5.2](https://hub.docker.com/layers/blockstack/stacks-signer/2.5.0.0.5.2/images/sha256-fc29a7c22f236f91270fb1aa58cfb4dd8dcd6b1daa0812e16df0bdc7643cb6ac?context=explore)
-* Stacks Node - [2.5.0.0.6](https://hub.docker.com/layers/blockstack/stacks-core/2.5.0.0.6/images/sha256-f6f17cd1399c5c4739ae34f7fc313775378f0bcbc5a985f0d7d02d008b5e9631?context=explore)
+* Stacks Node - [2.5.0.0.7](https://hub.docker.com/layers/blockstack/stacks-core/2.5.0.0.7/images/sha256-71d3eb305b5c1b68cd44904a7bcd6e5f92542135a7218762cdf27a46acaff69b?context=explore)
 
 ### Example Configs
 


### PR DESCRIPTION
## Description
Update `stacks-signer` and `stacks-node` versions to `2.5.0.0.5.2` and `2.5.0.0.7` respectively in all pages.