### PR TITLE
Adding undocumented setting

### DIFF
--- a/reference/sample-configuration-files.md
+++ b/reference/sample-configuration-files.md
@@ -28,6 +28,7 @@ The signer configuration file is a TOML file that contains the configuration opt
 | db\_path              | ✓        | Path to the signer's database file or :memory: for an in-memory database. |
 | metrics\_endpoint     |           | IP:PORT for Prometheus metrics collection. |
 | event\_timeout\_ms    |           | Time to wait (in milliseconds) for a response from the stacker-db instance. |
+| block\_proposal\_timeout\_ms    |           | Time to wait (in milliseconds) for a block response from miners. |
 | dkg\_public\_timeout\_ms |        | Timeout in (milliseconds) to gather DkgPublicShares messages. |
 | dkg\_private\_timeout\_ms |       | Timeout in (milliseconds) to gather DkgPrivateShares messages. |
 | dkg\_end\_timeout\_ms |           | Timeout in (milliseconds) to gather DkgEnd messages. |


### PR DESCRIPTION
## Description

Learned of a new signer option `block_proposal_timeout_ms` - useful in case a miner is slow to broadcast blocks, this allows the singer to wait longer before rejecting a block proposal from a valid miner. 

this setting is more relevant to distributed testnets/mocknets than mainnet.  