### PR TITLE
rename block_proposal_token -> auth_token

### DIFF
--- a/guides-and-tutorials/running-a-signer/README.md
+++ b/guides-and-tutorials/running-a-signer/README.md
@@ -82,7 +82,7 @@ Detailed steps for each of these are laid out below, but this checklist is being
 **Setting Up the Stacks Node**
 
 * [ ] Create a `node-config.toml` with the necessary settings:
-  * block\_proposal\_token
+  * auth\_token
   * events\_observer.endpoint (matching the signer configuration)
 * [ ] Decide whether to run the Stacks node using Docker or as a binary.
 * [ ] If using Docker:


### PR DESCRIPTION
`block_proposal_token` was replaced by `auth_token` in this PR https://github.com/stacks-network/docs/pull/1638 . 
Fixed a last reference to the old parameter.
