### PR TITLE
fix: remove unused config options from examples

### DIFF
--- a/nakamoto-upgrade/nakamoto-activation-guide-for-signers/setting-up-a-primary-post-nakamoto-testnet-node.md
+++ b/nakamoto-upgrade/nakamoto-activation-guide-for-signers/setting-up-a-primary-post-nakamoto-testnet-node.md
@@ -51,8 +51,6 @@ auth_token = "12345"
 
 [[events_observer]]
 endpoint = "0.0.0.0.0:30000"
-retry_count = 255
-include_data_events = false
 events_keys = ["stackerdb", "block_proposal", "burn_blocks"]
 
 [[ustx_balance]]
@@ -148,8 +146,6 @@ pox_reward_length = 900
 
 [[events_observer]]
 endpoint = "0.0.0.0.0:30000"
-retry_count = 255
-include_data_events = false
 events_keys = ["stackerdb", "block_proposal", "burn_blocks"]
 
 # Set your auth token, which the signer uses

--- a/reference/sample-configuration-files.md
+++ b/reference/sample-configuration-files.md
@@ -105,7 +105,6 @@ pox_reward_length = 900
 peer_host = "bitcoin.nakamoto.regtest.hiro.so"
 username = "hirosystems"
 password = "hirosystems"
-burnchain_op_tx_fee = 5500
 commit_anchor_block_within = 300000
 rpc_port = 18543
 peer_port = 18544
@@ -123,8 +122,6 @@ auth_token = "12345"
 [[events_observer]]
 # This endpoint is where your signer will communicate with your Stacks node
 endpoint = "127.0.0.1:30000"
-retry_count = 255
-include_data_events = false
 events_keys = ["stackerdb", "block_proposal", "burn_blocks"]
 
 [[burnchain.epochs]]
@@ -322,8 +319,6 @@ auth_token = "12345"
 [[events_observer]]
 # This endpoint is where your signer will communicate with your Stacks node
 endpoint = "127.0.0.1:30000"
-retry_count = 255
-include_data_events = false
 events_keys = ["stackerdb", "block_proposal", "burn_blocks"]
 
 [[ustx_balance]]
@@ -452,7 +447,5 @@ auth_token = "12345"
 [[events_observer]]
 # This endpoint is where your signer will communicate with your Stacks node
 endpoint = "127.0.0.1:30000"
-retry_count = 255
-include_data_events = false
 events_keys = ["stackerdb", "block_proposal", "burn_blocks"]
 ```

--- a/reference/stacks-node-configuration.md
+++ b/reference/stacks-node-configuration.md
@@ -144,6 +144,5 @@ peer_port = 8333
 
 [[events_observer]]
 endpoint = "localhost:3700"
-retry_count = 255
 events_keys = ["*"]
 ```


### PR DESCRIPTION
## Description

An upcoming update will error out if there are unknown fields in the config file. This removes some old fields from the examples.