### PR TITLE
Remove Clarity Function Argument

### DIFF
--- a/reference/functions.md
+++ b/reference/functions.md
@@ -2589,7 +2589,7 @@ This function returns (ok true) if the transfer is successful, or, on an error, 
 
 Introduced in: **Clarity 1**
 
-**input:** `uint, principal, principal, buff`
+**input:** `uint, principal, principal`
 
 **output:** `(response bool uint)`
 


### PR DESCRIPTION
The inputs of the `stx-transfer?` clarity function had an extra field named `buff`, which is not available for this function.