### PR TITLE
add tenure_idle_timeout_secs for signer sample config docs

### DIFF
--- a/guides-and-tutorials/running-a-signer/signer-quickstart.md
+++ b/guides-and-tutorials/running-a-signer/signer-quickstart.md
@@ -119,6 +119,7 @@ auth_password = "$AUTH_TOKEN"
 stacks_private_key = "$PRIVATE_KEY"
 metrics_endpoint = "127.0.0.1:9154"
 block_proposal_timeout_ms = 180000
+tenure_idle_timeout_secs = 120
 EOF
 ```
 {% endtab %}

--- a/reference/sample-configuration-files.md
+++ b/reference/sample-configuration-files.md
@@ -193,6 +193,7 @@ stacks_private_key = "$your_stacks_private_key"
 # The IP address and port where prometheus metrics can be accessed.
 metrics_endpoint = "127.0.0.1:9154"
 
+# Determining when a time-based tenure extend will be accepted
 tenure_idle_timeout_secs = 120
 ```
 

--- a/reference/sample-configuration-files.md
+++ b/reference/sample-configuration-files.md
@@ -192,6 +192,8 @@ stacks_private_key = "$your_stacks_private_key"
 
 # The IP address and port where prometheus metrics can be accessed.
 metrics_endpoint = "127.0.0.1:9154"
+
+tenure_idle_timeout_secs = 120
 ```
 
 ### Mainnet Stacks Node


### PR DESCRIPTION
adds `tenure_idle_timeout_secs = 120` for mainnet singer config samples