### PR TITLE
feat: Add Chainstate Snapshot/Backup guidelines

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -107,6 +107,7 @@
   * [Stack with a Pool](guides-and-tutorials/stack-stx/stack-with-a-pool.md)
   * [Increase Stacked Position](guides-and-tutorials/stack-stx/increase-stacking.md)
   * [Stop Stacking](guides-and-tutorials/stack-stx/stop-stacking.md)
+* [Snapshot the chainstate](guides-and-tutorials/best-practices-to-snapshot-the-chainstate.md)
 * [Oracles](guides-and-tutorials/oracles.md)
 * [Community Tutorials](guides-and-tutorials/community-tutorials.md)
 

--- a/guides-and-tutorials/best-practices-to-snapshot-the-chainstate.md
+++ b/guides-and-tutorials/best-practices-to-snapshot-the-chainstate.md
@@ -59,7 +59,8 @@ This method involves compressing the chainstate directory and storing it locally
 This method creates block-level snapshots of the entire storage volume containing the chainstate. Different filesystems have different tools:
 
 - **ZFS**: Use `zfs snapshot` - [OpenZFS documentation](https://openzfs.github.io/openzfs-docs/man/v2.3/8/zfs-snapshot.8.html)
-- **ext4 and XFS**: Use LVM snapshots - [LVM guide](https://kerneltalks.com/disk-management/how-to-guide-lvm-snapshot/)
+- **XFS**: Use `xfsdump` - [XFS documentation](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/7/html/storage_administration_guide/xfsbackuprestore)
+- **ext4**: Use LVM snapshots - [LVM guide](https://kerneltalks.com/disk-management/how-to-guide-lvm-snapshot/)
 
 You can also use cloud provider snapshot tools (AWS EBS, Azure Disk, GCP Persistent Disk).
 
@@ -72,6 +73,8 @@ You can also use cloud provider snapshot tools (AWS EBS, Azure Disk, GCP Persist
 3. **Restart the Stacks node**
 
 ## How to Restore
+
+*After restoring the chainstate, you can check for corruption by waiting for a few blocks to download and ensuring the node syncs correctly.*
 
 ### From File Snapshots
 

--- a/guides-and-tutorials/best-practices-to-snapshot-the-chainstate.md
+++ b/guides-and-tutorials/best-practices-to-snapshot-the-chainstate.md
@@ -40,7 +40,7 @@ There are two primary approaches for creating Stacks chainstate snapshots:
 
 Each method has its advantages depending on your infrastructure setup and recovery requirements.
 
-## File-Based Snapshots with External Storage
+## File-Based Snapshots
 
 This method involves compressing the chainstate directory, storing it locally or uploading it to a cloud storage services.
 

--- a/guides-and-tutorials/best-practices-to-snapshot-the-chainstate.md
+++ b/guides-and-tutorials/best-practices-to-snapshot-the-chainstate.md
@@ -4,7 +4,7 @@
 **Intended audience**: Solo Stackers, Stacking pool operators, and node operators who need to create reliable chainstate backups.
 {% endhint %}
 
-Creating regular snapshots of your Stacks chainstate is crucial for fast recovery, redundancy, and minimizing downtime. This guide outlines best practices for creating and managing chainstate snapshots.
+Regular snapshots of your Stacks chainstate help you recover quickly when things go wrong. This guide shows you how to create and manage chainstate snapshots properly.
 
 {% hint style="warning" %}
 **Critical**: Always shut down your Stacks node properly before creating a snapshot. Creating snapshots while the node is running will result in corrupted state data.
@@ -35,8 +35,8 @@ To produce a valid chainstate backup, the node should be stopped gracefully befo
 
 There are two primary approaches for creating Stacks chainstate snapshots:
 
-1. **File-based snapshots**
-2. **Volume snapshots**
+1. **File-based snapshots** - zip up the chainstate folder
+2. **Volume snapshots** - snapshot the entire disk/volume
 
 Each method has its advantages depending on your infrastructure setup and recovery requirements.
 
@@ -72,9 +72,9 @@ if the filesystem is supported or using cloud native tools.
 
 3. **Restart the Stacks node**
 
-## Recovery Procedures
+## How to Restore
 
-### From File-Based Snapshots
+### From File Snapshots
 
 1. Stop the Stacks node
 2. Download and extract the snapshot
@@ -91,7 +91,7 @@ if the filesystem is supported or using cloud native tools.
 
 ## Example Automation Code
 
-This section contains a simplified automation script for both file-based and volume-based snapshot creation using AWS.
+Here's a simple script that handles both file and volume snapshots on AWS.
 
 ```bash
 #!/bin/bash
@@ -190,21 +190,21 @@ main() {
 main
 ```
 
-### Usage Instructions
+### How to Use
 
-1. **Configure variables**: Modify the variables at the top of the script for your environment
+1. **Edit the variables** at the top of the script for your setup
 
-2. **Set permissions**: Make the script executable with `chmod +x snapshot.sh`
+2. **Make it executable**: `chmod +x snapshot.sh`
 
-3. **Run the script**: Execute `./snapshot.sh`
+3. **Run it**: `./snapshot.sh`
 
-4. **Schedule automation using a crontab**: 
+4. **Schedule it with cron** for daily backups: 
    ```bash
    # Daily snapshot at 2 AM
    0 2 * * * /path/to/snapshot.sh
    ```
 
-### Prerequisites
+### What You Need
 
-- AWS CLI configured with appropriate permissions
-- `pzstd` installed for compression (part of zstd package)
+- AWS CLI set up with the right permissions
+- `pzstd` installed (comes with the zstd package)

--- a/guides-and-tutorials/best-practices-to-snapshot-the-chainstate.md
+++ b/guides-and-tutorials/best-practices-to-snapshot-the-chainstate.md
@@ -1,0 +1,278 @@
+# Best Practices for Stacks Chainstate Snapshots
+
+{% hint style="info" %}
+**Intended audience**: Solo Stackers, Stacking pool operators, and node operators who need to create reliable chainstate backups.
+{% endhint %}
+
+Creating regular snapshots of your Stacks chainstate is crucial for fast recovery, redundancy, and minimizing downtime. This guide outlines best practices for creating and managing chainstate snapshots.
+
+{% hint style="warning" %}
+**Critical**: Always shut down your Stacks node properly before creating a snapshot. Creating snapshots while the node is running will result in corrupted state data.
+{% endhint %}
+
+## Overview of Snapshot Methods
+
+There are two primary approaches for creating Stacks chainstate snapshots:
+
+1. **File-based snapshots**: Compress and store chainstate data in external storage
+2. **Volume snapshots**: Create block-level snapshots of the storage volume
+
+Each method has its advantages depending on your infrastructure setup and recovery requirements.
+
+## Method 1: File-Based Snapshots with External Storage
+
+This method involves compressing the chainstate directory and uploading it to cloud storage services.
+
+### Advantages
+- Platform agnostic
+- Easy to transfer between different environments
+- Granular control over what gets backed up
+
+### Prerequisites
+- Sufficient local disk space for compression
+- Configured cloud storage access
+- Backup automation tools or cloud providers CLI
+
+### Supported Cloud Storage Providers
+
+#### Amazon Web Services (S3)
+
+- **Service**: [Amazon S3](https://aws.amazon.com/s3/)
+- **CLI Tool**: [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+- **Storage Classes**: Standard, Standard-IA, Glacier for different cost/access patterns
+
+#### Microsoft Azure (Blob Storage)
+
+- **Service**: [Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs)
+- **CLI Tool**: [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
+- **Storage Tiers**: Hot, Cool, Archive for cost optimization
+
+#### Google Cloud Platform (Cloud Storage)
+
+- **Service**: [Google Cloud Storage](https://cloud.google.com/storage)
+- **CLI Tool**: [gcloud CLI](https://cloud.google.com/sdk/docs/install)
+- **Storage Classes**: Standard, Nearline, Coldline, Archive
+
+### File-Based Snapshot Process
+
+1. **Stop the Stacks node gracefully**
+
+2. **Create compressed archive**
+
+3. **Upload to cloud storage** (examples provided in automation section below)
+
+4. **Restart the Stacks node**
+
+## Method 2: Volume-Based Snapshots
+
+This method creates block-level snapshots of the entire storage volume containing the chainstate.
+
+### Advantages
+
+- Faster backup and restore operations
+- Atomic snapshots (entire volume state at a point in time)
+- No local disk space required for compression
+- Native cloud provider integration
+
+### Supported Cloud Providers
+
+#### Amazon Web Services (EBS Snapshots)
+
+- **Service**: [Amazon EBS Snapshots](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSSnapshots.html)
+- **CLI**: AWS CLI or AWS Console
+
+#### Microsoft Azure (Disk Snapshots)
+
+- **Service**: [Azure Managed Disk Snapshots](https://learn.microsoft.com/en-us/azure/virtual-machines/snapshot-copy-managed-disk)
+- **CLI**: Azure CLI or Azure Portal
+
+#### Google Cloud Platform (Persistent Disk Snapshots)
+
+- **Service**: [Compute Engine Persistent Disk Snapshots](https://cloud.google.com/compute/docs/disks/snapshots)
+- **CLI**: gcloud CLI or Google Cloud Console
+
+### Volume Snapshot Process
+
+1. **Stop the Stacks node gracefully** (same as file-based method)
+
+2. **Create volume snapshot** using cloud provider tools
+
+3. **Restart the Stacks node**
+
+## Critical Shutdown Procedures
+
+{% hint style="danger" %}
+**Never create snapshots while the Stacks node is running!** This will result in corrupted chainstate data that cannot be used for recovery.
+{% endhint %}
+
+### Proper Shutdown Steps
+
+1. **Check node status** before shutdown
+   ```bash
+   # Verify node is responsive
+   curl http://localhost:20443/v2/info
+   ```
+
+2. **Initiate graceful shutdown**
+   - For Docker: `docker stop stacks-node` (allows at 10 seconds for graceful shutdown)
+   - For systemd: `systemctl stop stacks-node`
+   - For manual processes: Send SIGTERM signal
+
+3. **Verify complete shutdown**
+   ```bash
+   # Ensure no stacks-node processes are running
+   ps aux | grep stacks-node
+   ```
+
+## Snapshot Scheduling and Retention
+
+### Recommended Schedule
+- **Daily snapshots**: For active production nodes
+- **Weekly snapshots**: For development or test environments
+
+## Recovery Procedures
+
+### From File-Based Snapshots
+
+1. Stop the Stacks node
+2. Download and extract the snapshot
+3. Replace the chainstate directory
+4. Restart the node
+
+### From Volume Snapshots
+
+1. Stop the Stacks node
+2. Create a new volume from the snapshot
+3. Attach the volume to your instance
+4. Update mount points if necessary
+5. Restart the node
+
+## Monitoring and Validation
+
+### Snapshot Validation
+
+- **File integrity**: Verify checksums of compressed archives
+- **Volume consistency**: Use cloud provider validation tools
+- **Test recovery**: Periodically test snapshot restoration in a test environment
+
+## Example Automation Code
+
+This section contains a simplified automation script for both file-based and volume-based snapshot creation using AWS.
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Configuration variables - modify these for your setup
+SERVICE_NAME="stacks-node"                   # systemd service name
+SNAPSHOT_DIR="/var/stacks/mainnet"           # path to chainstate directory
+SNAPSHOT_BASE="/tmp"                         # temporary directory for archives
+EBS_VOLUME_ID="vol-1234567890abcdef0"        # EBS volume ID containing chainstate
+S3_BUCKET="s3://my-stacks-snapshots"         # S3 bucket for archive storage
+SNAPSHOT_TYPE="both"                         # Options: ebs, archive, or both
+
+# Stop the Stacks node service gracefully
+stop_service() {
+  echo "Stopping $SERVICE_NAME..."
+  sudo systemctl stop "$SERVICE_NAME"
+}
+
+# Start the Stacks node service
+start_service() {
+  echo "Starting $SERVICE_NAME..."
+  sudo systemctl start "$SERVICE_NAME"
+}
+
+# Create compressed archive and upload to S3
+snapshot_archive() {
+  echo "Creating archive snapshot..."
+  
+  # Generate timestamp and version info for filename
+  TIMESTAMP=$(date +"%Y%m%d")
+  DIR_NAME=$(basename "$SNAPSHOT_DIR")
+  VERSION=$(stacks-node version 2>&1 | tail -n 1 | awk '{print $2}')
+  DEST="$SNAPSHOT_BASE/$DIR_NAME-$VERSION-$TIMESTAMP.tar.zst"
+  
+  # Create compressed archive (using zstd for better compression)
+  tar -cf - -C "$(dirname $SNAPSHOT_DIR)" "$(basename $SNAPSHOT_DIR)" | pzstd -o "$DEST"
+  echo "Archive created at: $DEST"
+
+  # Upload to S3
+  echo "Uploading to S3..."
+  aws s3 cp "$DEST" "$S3_BUCKET/"
+  echo "S3 upload complete: $S3_BUCKET/$(basename "$DEST")"
+  
+  # Clean up local archive
+  rm "$DEST"
+}
+
+# Create EBS volume snapshot
+snapshot_ebs() {
+  echo "Creating EBS snapshot of $EBS_VOLUME_ID..."
+  
+  # Generate description with timestamp
+  TIMESTAMP=$(date +"%Y%m%d")
+  DESC="Stacks Node Snapshot - $TIMESTAMP"
+  
+  # Create snapshot with tags
+  SNAPSHOT_ID=$(aws ec2 create-snapshot \
+                  --volume-id "$EBS_VOLUME_ID" \
+                  --description "$DESC" \
+                  --tag-specifications "ResourceType=snapshot,Tags=[{Key=Name,Value=Stacks Snapshot},{Key=type,Value=chainstate}]" \
+                  --query 'SnapshotId' --output text)
+
+  echo "EBS Snapshot ID: $SNAPSHOT_ID"
+}
+
+# Main execution function
+main() {
+  case "$SNAPSHOT_TYPE" in
+    ebs)
+      stop_service
+      snapshot_ebs
+      start_service
+      ;;
+    archive)
+      stop_service
+      snapshot_archive
+      start_service
+      ;;
+    both)
+      stop_service
+      snapshot_archive  # Create archive first
+      snapshot_ebs      # Then EBS snapshot
+      start_service
+      ;;
+    *)
+      echo "Invalid snapshot type: $SNAPSHOT_TYPE. Available options: ebs, archive, or both."
+      exit 1
+      ;;
+  esac
+  
+  echo "Snapshot process completed successfully!"
+}
+
+# Execute main function
+main
+```
+
+### Usage Instructions
+
+1. **Configure variables**: Modify the variables at the top of the script for your environment
+
+2. **Set permissions**: Make the script executable with `chmod +x snapshot.sh`
+
+3. **Run the script**: Execute `./snapshot.sh`
+
+4. **Schedule automation**: Add to crontab for regular execution:
+   ```bash
+   # Daily snapshot at 2 AM
+   0 2 * * * /path/to/snapshot.sh
+   ```
+
+### Prerequisites
+
+- AWS CLI configured with appropriate permissions
+- `pzstd` installed for compression (part of zstd package)
+- `stacks-node` binary in PATH for version detection
+- Sufficient disk space in `SNAPSHOT_BASE` directory for archive creation

--- a/guides-and-tutorials/running-a-signer/README.md
+++ b/guides-and-tutorials/running-a-signer/README.md
@@ -263,7 +263,7 @@ For example:
 
 **Warning:** It is always better to keep a local snapshot of the chain state for fast recovery and redundancy. This ensures you can quickly restore your node in case of data loss or corruption.
 
-See [here](./best-practices-to-snapshot-the-chainstate.md) for additional best practices to create a local chainstate snapshot.
+See [here](../best-practices-to-snapshot-the-chainstate.md) for additional best practices to create a local chainstate snapshot.
 {% endhint %}
 
 #### Run a Stacks Node with Docker

--- a/guides-and-tutorials/running-a-signer/README.md
+++ b/guides-and-tutorials/running-a-signer/README.md
@@ -261,9 +261,14 @@ For example:
 * You will set working\_dir to equal ”/Users/blah”
   * Note that the string does not include the `mainnet` part
 
+**Warning:** It is always better to keep a local snapshot of the chain state for fast recovery and redundancy. This ensures you can quickly restore your node in case of data loss or corruption.
+
+See [here](./best-practices-to-snapshot-the-chainstate.md) for additional best practices to create a local chainstate snapshot.
+{% endhint %}
+
 #### Run a Stacks Node with Docker
 
-You can run the Stacks node as a Docker container using the `blockstack/stacks-core` image, currently on [version 3.1.0.0.5](https://hub.docker.com/layers/blockstack/stacks-core/3.1.0.0.5/images/sha256-cf2c04b6f56d7a54c2032a13826ebb258cebe50a30b847810a279476824bd2c0). When running the Docker container, you’ll need to ensure a few things:
+You can run the Stacks node as a Docker container using the `blockstack/stacks-core` image, currently on [version 3.1.0.0.13](https://hub.docker.com/layers/blockstack/stacks-core/3.1.0.0.13/images/sha256:2f87331740c3afbe69b6e9bd572ebe991c95191731a9e135de66084871c1f2ad). When running the Docker container, you’ll need to ensure a few things:
 
 * The port configured for `p2p_bind` must be exposed to the internet
 * The port configured for `rpc_bind` must be accessible by your signer
@@ -274,7 +279,7 @@ An example for running the node’s Docker image with docker run is below. Be su
 
 ```bash
 IMG="blockstack/stacks-core"
-VER="3.1.0.0.5"
+VER="3.1.0.0.13"
 STX_NODE_CONFIG="./node-config.toml"
 
 docker run -d \
@@ -292,7 +297,7 @@ docker run -d \
 Or, using a custom Dockerfile:
 
 ```docker
-FROM blockstack/stacks-core:3.1.0.0.5
+FROM blockstack/stacks-core:3.1.0.0.13
 COPY node-config.toml /config.toml
 EXPOSE 20444
 EXPOSE 20443


### PR DESCRIPTION
## Description

This PR adds a guidelines on how to snapshot and backup the Stacks Chainstate in order to mitigate the Signers downtime and help partners to improve the DR and resiliency.