### PR TITLE
Add id-token: write permission for OIDC authentication

### DIFF
--- a/.github/workflows/smart-docs-monitor.yml
+++ b/.github/workflows/smart-docs-monitor.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: read
   issues: write
+  id-token: write
 
 jobs:
   monitor:


### PR DESCRIPTION
Fixes the OIDC token error in the Smart Docs Monitor workflow.

The Claude Code Action requires `id-token: write` permission to use OIDC authentication for automatically obtaining GitHub tokens.

Error was:
```
Failed to setup GitHub token: Error: Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

This PR adds the missing permission.