### PR TITLE
fixed pdf src paths that didn't auto update in Gitbook

### DIFF
--- a/docs/learn/sbtc/security-model-of-sbtc/sbtc-audits.md
+++ b/docs/learn/sbtc/security-model-of-sbtc/sbtc-audits.md
@@ -2,10 +2,10 @@
 
 Several third-party security audits have been conducted on the sBTC system and can be referenced here.
 
-{% file src="../.gitbook/assets/Ottersec - stacks_wsts_audit_final.pdf" %}
+{% file src="../../.gitbook/assets/Ottersec - stacks_wsts_audit_final.pdf" %}
 
-{% file src="../.gitbook/assets/Ottersec - stacks_sbtc_audit_final.pdf" %}
+{% file src="../../.gitbook/assets/Ottersec - stacks_sbtc_audit_final.pdf" %}
 
-{% file src="../.gitbook/assets/CoinFabrik_WSTS.pdf" %}
+{% file src="../../.gitbook/assets/CoinFabrik_WSTS.pdf" %}
 
-{% file src="../.gitbook/assets/Clarity Alliance - sBTC-2.pdf" %}
+{% file src="../../.gitbook/assets/Clarity Alliance - sBTC-2.pdf" %}


### PR DESCRIPTION
## Description

Moved the sBTC Audits page into a new grouping in the Gitbook UI, but the pdf src paths didn't auto update. This PR fixes those paths.