### PR TITLE
docs: Remove hardcoded links in testing tutorial

### DIFF
--- a/docs/tutorials/bitcoin-primer/stacks-development-fundamentals/testing-clarity-contracts.md
+++ b/docs/tutorials/bitcoin-primer/stacks-development-fundamentals/testing-clarity-contracts.md
@@ -4,9 +4,9 @@ Now we need to modify our tests to make sure we handled this new message functio
 
 There are two sections of the docs to check to understand how to write Clarity unit tests.
 
-The first is the series of [Clarinet JS SDK guides](https://docs.stacks.co/clarinet-js-sdk/overview) in the Build section. These will show you how to work with the SDK to write your tests.
+The first is the series of Clarinet JS SDK guides in the Build section. These will show you how to work with the SDK to write your tests.
 
-The second is the [Clarinet JS SDK reference](https://docs.stacks.co/reference/clarinet-js-sdk/sdk-reference) section. This will show you all of the available functions you can use to write your tests.
+The second is the Clarinet JS SDK reference section. This will show you all of the available functions you can use to write your tests.
 
 Let's make a few modifications to our test file.
 


### PR DESCRIPTION
## Description
Removed hardcoded `https://docs.stacks.co` URLs from testing tutorial to improve documentation maintainability.

## Changes
- ✅ Removed 2 hardcoded URL references
- ✅ Kept the text descriptions for clarity

## Why This Helps
Hardcoded URLs in the source documentation create maintenance overhead. Text references are cleaner and don't break when documentation structure changes.