### PR TITLE
docs: add signer-node HTTPS proxy guidance

### DIFF
--- a/docs/reference/node-operations/signer-configuration.md
+++ b/docs/reference/node-operations/signer-configuration.md
@@ -22,6 +22,14 @@ The signer configuration file is a TOML file that contains the configuration opt
 | metrics\_endpoint            |          | IP:PORT for Prometheus metrics collection.                                                                                                                                                                                                                                                    |
 | chain\_id                    |          | An optional ChainID, only used for custom networks (like Nakamoto Testnet)                                                                                                                                                                                                                    |
 
+{% hint style="info" %}
+Need encrypted traffic between signer and node on separate hosts?
+
+`node_host` and `events_observer.endpoint` should remain `IP:PORT` values (not `https://...` URLs). Use local loopback proxy endpoints in these fields and have your proxy layer handle TLS to the remote host.
+
+See the [Run a Signer guide](../../operate/run-a-signer/) for a full HTTPS proxy example.
+{% endhint %}
+
 #### Example Configs
 
 Below are sample configuration files for running a Stacks node and signer provided in one place for convenience. You'll need to modify some of these according to the [How to Run a Signer](/broken/pages/261edd335c0b98fb052ad55906fbf90832800453) doc.


### PR DESCRIPTION
Fixes #1627

## Summary
- Add documentation for running signer and stacks-node over encrypted links when they are hosted on separate machines.
- Document a reverse-proxy pattern that preserves required `IP:PORT` config fields while adding TLS between hosts.
- Add an explicit operator validation checklist.

## Changes
- `docs/operate/run-a-signer/README.md`
  - Added an `Optional: TLS between signer and node on separate hosts` section.
  - Added traffic-path mapping for both directions:
  - `stacks-node -> signer` events flow through local proxy + HTTPS.
  - `stacks-signer -> stacks-node` RPC flow through local proxy + HTTPS.
  - Added concrete `signer-config.toml` and `node-config.toml` examples using loopback proxy endpoints.
  - Added Nginx examples for node host and signer host.
  - Added validation checklist (`curl`, certificate verification, logs).
- `docs/reference/node-operations/signer-configuration.md`
  - Added guidance that `node_host` and `events_observer.endpoint` remain `IP:PORT` values (not `https://...`).
  - Added note to use local loopback proxies for TLS and linked to run guide.

## Testing
```bash
npx --yes markdownlint-cli --disable MD001 MD013 MD022 MD024 MD031 MD034 MD040 -- docs/operate/run-a-signer/README.md docs/reference/node-operations/signer-configuration.md
echo "exit_code=$?"
# exit_code=0
```

## Checklist
- [x] Required documentation updates included
- [x] Changes are scoped to docs only
- [x] Test evidence included
