### PR TITLE
docs: add epoch 3.3 activation to config examples

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -231,5 +231,9 @@ start_height = 2_000
 [[burnchain.epochs]]
 epoch_name = "3.2"
 start_height = 71_525
+
+[[burnchain.epochs]]
+epoch_name = "3.3"
+start_height = 108_800
 ```
 {% endcode %}

--- a/docs/reference/nakamoto-upgrade/setting-up-a-primary-post-nakamoto-testnet-node.md
+++ b/docs/reference/nakamoto-upgrade/setting-up-a-primary-post-nakamoto-testnet-node.md
@@ -116,6 +116,10 @@ start_height = 2_000
 [[burnchain.epochs]]
 epoch_name = "3.2"
 start_height = 71_525
+
+[[burnchain.epochs]]
+epoch_name = "3.3"
+start_height = 108_800
 EOF
 
 docker run -d  \\
@@ -225,6 +229,10 @@ start_height = 2_000
 [[burnchain.epochs]]
 epoch_name = "3.2"
 start_height = 71_525
+
+[[burnchain.epochs]]
+epoch_name = "3.3"
+start_height = 108_800
 ```
 
 Important aspects to change:

--- a/docs/reference/node-operations/signer-configuration.md
+++ b/docs/reference/node-operations/signer-configuration.md
@@ -164,6 +164,10 @@ start_height = 2_000
 [[burnchain.epochs]]
 epoch_name = "3.2"
 start_height = 71_525
+
+[[burnchain.epochs]]
+epoch_name = "3.3"
+start_height = 108_800
 ```
 
 #### Mainnet Signer


### PR DESCRIPTION
Fixes #1742

## Summary
- Update testnet configuration examples to include epoch `3.3`.
- Add epoch `3.3` activation height `108_800` immediately after epoch `3.2` in reference config snippets.
- Keep docs aligned with stacks-core epoch 3.3 activation changes.

## Changes
- `docs/reference/README.md`
  - Added:
  - `epoch_name = "3.3"`
  - `start_height = 108_800`
- `docs/reference/node-operations/signer-configuration.md`
  - Added epoch `3.3` (`108_800`) in the testnet signer+node sample config.
- `docs/reference/nakamoto-upgrade/setting-up-a-primary-post-nakamoto-testnet-node.md`
  - Added epoch `3.3` (`108_800`) in both testnet node config examples.

## Testing
```bash
npx --yes markdownlint-cli --disable MD001 MD013 MD022 MD024 MD031 MD034 MD036 MD040 -- docs/reference/README.md docs/reference/node-operations/signer-configuration.md docs/reference/nakamoto-upgrade/setting-up-a-primary-post-nakamoto-testnet-node.md
echo "exit_code=$?"
# exit_code=0
```

## Checklist
- [x] Required documentation updates included
- [x] Changes are scoped to docs only
- [x] Test evidence included
