### PR TITLE
docs: Add DeFi Sentinel to devtools catalog

### DIFF
--- a/docs/build/stacks-devtools-catalog.md
+++ b/docs/build/stacks-devtools-catalog.md
@@ -110,6 +110,7 @@ Official Stacks devtools are built and maintained by either **Stacks Labs** or *
 <summary>Community &#x26; Experimental</summary>
 
 * [**STXER**](https://stxer.xyz/) - Community built explorer, debugger and simulator for Stacks transactions.
+* [**DeFi Sentinel**](https://github.com/serayd61/stacks-defi-sentinel) - Real-time DeFi monitoring dashboard for Stacks with whale alerts, DEX tracking, portfolio analytics, and Chainhooks integration.
 
 </details>
 


### PR DESCRIPTION
## Summary

This PR adds **DeFi Sentinel** to the Stacks Devtools Catalog under the Monitoring & Analytics section (Community & Experimental).

## What is DeFi Sentinel?

DeFi Sentinel is a real-time DeFi monitoring dashboard for Stacks that provides:

- **Whale Alerts**: Track large STX movements in real-time
- **DEX Tracking**: Monitor swaps and liquidity across Stacks DEXes
- **Portfolio Analytics**: Analyze wallet holdings and transaction history
- **Chainhooks Integration**: Real-time blockchain event monitoring
- **Network Health**: Live network statistics and block monitoring

## Links

- **GitHub**: https://github.com/serayd61/stacks-defi-sentinel
- **Live Demo**: https://defi-sentinel.xyz

## Why add this?

DeFi Sentinel fills a gap in the Stacks ecosystem for real-time DeFi monitoring tools, helping developers and users track on-chain activity efficiently.

## Checklist

- [x] Added to appropriate section (Monitoring & Analytics > Community & Experimental)
- [x] Follows existing format
- [x] Link is valid and project is open source

Made with [Cursor](https://cursor.com)