### PR TITLE
Update docker namespace

### DIFF
--- a/docs/build/clarinet/local-blockchain-development.md
+++ b/docs/build/clarinet/local-blockchain-development.md
@@ -222,8 +222,8 @@ epoch_3_0 = 101   # Nakamoto activation at block 101
 
 Clarinet runs Devnet with specific tags for each Docker image. For example, Clarinet v3.10.0 uses the following images:
 
-* stacks node: `blockstack/stacks-blockchain:3.3.0.0.1-alpine`
-* stacks signer: `blockstack/stacks-signer:3.3.0.0.1.0-alpine`
+* stacks node: `blockstack/stacks-core:3.3.0.0.6-alpine`
+* stacks signer: `blockstack/stacks-signer:3.3.0.0.6.0-alpine`
 
 We recommend Devnet users let Clarinet handle it and use the default version. This ensures that your Clarinet version can handle and properly configure the images it uses.
 
@@ -238,8 +238,8 @@ deployment_fee_rate = 10
 # ...
 
 [devnet]
-stacks_node_image_url = "blockstack/stacks-blockchain:3.3.0.0.1"
-stacks_signer_image_url = "blockstack/stacks-signer:3.3.0.0.1.0"
+stacks_node_image_url = "blockstack/stacks-core:3.3.0.0.6"
+stacks_signer_image_url = "blockstack/stacks-signer:3.3.0.0.6.0"
 ```
 
 <details>

--- a/docs/operate/run-a-miner/mine-mainnet-stacks-tokens.md
+++ b/docs/operate/run-a-miner/mine-mainnet-stacks-tokens.md
@@ -255,7 +255,7 @@ docker run -d \
   -v "/stacks-blockchain:/stacks-blockchain" \
   -p 20443:20443 \
   -p 20444:20444 \
-  blockstack/stacks-blockchain:latest \
+  blockstack/stacks-core:latest \
 /bin/stacks-node start --config /src/stacks-node/mainnet-miner-conf.toml
 ```
 

--- a/docs/operate/run-a-miner/mine-testnet-stacks-tokens.md
+++ b/docs/operate/run-a-miner/mine-testnet-stacks-tokens.md
@@ -268,7 +268,7 @@ docker run -d \
   -v "/stacks-blockchain:/stacks-blockchain" \
   -p 20443:20443 \
   -p 20444:20444 \
-  blockstack/stacks-blockchain:latest \
+  blockstack/stacks-core:latest \
 /bin/stacks-node start --config /src/stacks-node/testnet-miner-conf.toml
 ```
 


### PR DESCRIPTION
band-aid  to update the docker namespace to fix outdated namespace of `blockstack/stacks-blockchain`. 
this image name is deprecated and shall not be mirrored. 

potentially a larger update is needed to reflect the default image location change to ghcr, but that is not addressed in this PR. 