### PR TITLE
Updating testnet configs for epoch 3.4 and align to match stacks-core…

### DIFF
--- a/docs/operate/run-a-signer/signer-quickstart.md
+++ b/docs/operate/run-a-signer/signer-quickstart.md
@@ -342,11 +342,23 @@ start_height = 6
 
 [[burnchain.epochs]]
 epoch_name = "3.0"
-start_height = 1_900
+start_height = 1900
 
 [[burnchain.epochs]]
 epoch_name = "3.1"
-start_height = 2_000
+start_height = 2000
+
+[[burnchain.epochs]]
+epoch_name = "3.2"
+start_height = 71525
+
+[[burnchain.epochs]]
+epoch_name = "3.3"
+start_height = 109280
+
+[[burnchain.epochs]]
+epoch_name = "3.4"
+start_height = 159345
 EOF
 ```
 {% endtab %}

--- a/docs/operate/run-a-signer/signer-quickstart.md
+++ b/docs/operate/run-a-signer/signer-quickstart.md
@@ -358,7 +358,7 @@ start_height = 109280
 
 [[burnchain.epochs]]
 epoch_name = "3.4"
-start_height = 159345
+start_height = 159350
 EOF
 ```
 {% endtab %}

--- a/docs/reference/README (1).md
+++ b/docs/reference/README (1).md
@@ -222,14 +222,22 @@ start_height = 6
 
 [[burnchain.epochs]]
 epoch_name = "3.0"
-start_height = 1_900
+start_height = 1900
 
 [[burnchain.epochs]]
 epoch_name = "3.1"
-start_height = 2_000
+start_height = 2000
 
 [[burnchain.epochs]]
 epoch_name = "3.2"
-start_height = 71_525
+start_height = 71525
+
+[[burnchain.epochs]]
+epoch_name = "3.3"
+start_height = 109280
+
+[[burnchain.epochs]]
+epoch_name = "3.4"
+start_height = 159345
 ```
 {% endcode %}

--- a/docs/reference/README (1).md
+++ b/docs/reference/README (1).md
@@ -238,6 +238,6 @@ start_height = 109280
 
 [[burnchain.epochs]]
 epoch_name = "3.4"
-start_height = 159345
+start_height = 159350
 ```
 {% endcode %}

--- a/docs/reference/nakamoto-upgrade/setting-up-a-primary-post-nakamoto-testnet-node.md
+++ b/docs/reference/nakamoto-upgrade/setting-up-a-primary-post-nakamoto-testnet-node.md
@@ -107,15 +107,23 @@ start_height = 6
 
 [[burnchain.epochs]]
 epoch_name = "3.0"
-start_height = 1_900
+start_height = 1900
 
 [[burnchain.epochs]]
 epoch_name = "3.1"
-start_height = 2_000
+start_height = 2000
 
 [[burnchain.epochs]]
 epoch_name = "3.2"
-start_height = 71_525
+start_height = 71525
+
+[[burnchain.epochs]]
+epoch_name = "3.3"
+start_height = 109280
+
+[[burnchain.epochs]]
+epoch_name = "3.4"
+start_height = 159345
 EOF
 
 docker run -d  \\

--- a/docs/reference/nakamoto-upgrade/setting-up-a-primary-post-nakamoto-testnet-node.md
+++ b/docs/reference/nakamoto-upgrade/setting-up-a-primary-post-nakamoto-testnet-node.md
@@ -123,7 +123,7 @@ start_height = 109280
 
 [[burnchain.epochs]]
 epoch_name = "3.4"
-start_height = 159345
+start_height = 159350
 EOF
 
 docker run -d  \\

--- a/docs/reference/node-operations/signer-configuration.md
+++ b/docs/reference/node-operations/signer-configuration.md
@@ -171,7 +171,7 @@ start_height = 109280
 
 [[burnchain.epochs]]
 epoch_name = "3.4"
-start_height = 159345
+start_height = 159350
 ```
 
 #### Mainnet Signer

--- a/docs/reference/node-operations/signer-configuration.md
+++ b/docs/reference/node-operations/signer-configuration.md
@@ -155,15 +155,23 @@ start_height = 6
 
 [[burnchain.epochs]]
 epoch_name = "3.0"
-start_height = 1_900
+start_height = 1900
 
 [[burnchain.epochs]]
 epoch_name = "3.1"
-start_height = 2_000
+start_height = 2000
 
 [[burnchain.epochs]]
 epoch_name = "3.2"
-start_height = 71_525
+start_height = 71525
+
+[[burnchain.epochs]]
+epoch_name = "3.3"
+start_height = 109280
+
+[[burnchain.epochs]]
+epoch_name = "3.4"
+start_height = 159345
 ```
 
 #### Mainnet Signer


### PR DESCRIPTION
Adding Epoch 3.4 to testnet configs and updating other block heights to match the sample configs from 
- https://github.com/stacks-network/stacks-core/blob/master/sample/conf/testnet-follower-conf.toml
- https://github.com/stacks-network/stacks-core/blob/master/sample/conf/testnet-miner-conf.toml