### PR TITLE
Wire up remaining cross-references to migrated Hiro content

### DIFF
--- a/docs/build/get-started/developer-quickstart.md
+++ b/docs/build/get-started/developer-quickstart.md
@@ -378,7 +378,7 @@ Emitting events on Stacks serves several critical purposes:
 1. **Transparency**: Events provide an on-chain record of actions and transactions, ensuring transparency.
 2. **Notification**: They serve as a signal mechanism for users and external applications, notifying them of specific occurrences on Stacks.
 3. **State Tracking**: Developers can use events to track changes in the state of smart contracts without querying the chain continuously.
-4. **Efficient Data Handling**: By emitting events, webhook services, such as Hiro's [Chainhooks](https://docs.hiro.so/en/tools/chainhooks), can filter and handle relevant data efficiently, reducing the on-chain computation load.
+4. **Efficient Data Handling**: By emitting events, webhook services, such as Hiro's [Chainhooks](../chainhooks/overview.md), can filter and handle relevant data efficiently, reducing the on-chain computation load.
 
 </details>
 
@@ -811,7 +811,7 @@ function App() {
 </code></pre>
 
 {% hint style="info" %}
-For the complete set of available API endpoints for the Stacks network, check out the [Hiro docs](https://docs.hiro.so/). But first create an API key from the [Hiro Platform](https://platform.hiro.so/) to determine your API rate plan.
+For indexed Stacks API endpoints, see the [Stacks Blockchain API reference](../../reference/api/stacks-blockchain-api/README.md). Create an API key in [Hiro Platform](https://platform.hiro.so/) and review [API Keys](../../reference/api/api-keys.md) and [Rate Limits](../../reference/api/rate-limits.md) before you ship to production.
 {% endhint %}
 {% endstep %}
 {% endstepper %}
@@ -825,7 +825,7 @@ And that's it, you've successfully created an sBTC powered Clarity smart contrac
 This is just the beginning. There are many ways we can improve upon this app. Here are some suggestions for you to extend the functionality of this app:
 
 * Deploy to mainnet and share your project with the community
-* Use [Chainhooks](https://docs.hiro.so/en/tools/chainhooks) to index emitted events from the contract
+* Use [Chainhooks](../chainhooks/overview.md) to index emitted events from the contract
 * Integrate the [`sbtc`](../more-guides/sbtc/bridging-bitcoin/) library so users can directly bridge their BTC to sBTC in-app
 * Utilize SIP-009 NFTs to uniquely identify each message for each author
 

--- a/docs/build/get-started/path-to-production.md
+++ b/docs/build/get-started/path-to-production.md
@@ -39,7 +39,7 @@ To ensure your app or smart contract is production-ready, we pulled together a s
 {% step %}
 ### Specific Clarity/Stacks.js best practices
 
-* [**Post-conditions**](/broken/pages/0KPrPPKItMGZZL2u4tiF): Post conditions are an additional safety feature built into the Stacks chain itself that help to protect end users. Rather than being a function of Clarity smart contracts, they are implemented on the client side and meant to be an additional failsafe against malicious contracts.
+* [**Post-conditions**](../post-conditions/overview.md): Post conditions are an additional safety feature built into the Stacks chain itself that help to protect end users. Rather than being a function of Clarity smart contracts, they are implemented on the client side and meant to be an additional failsafe against malicious contracts.
 * [**Usage of `tx-sender` vs `contract-caller`**](https://www.setzeus.com/public-blog-post/clarity-carefully-tx-sender) : The usage of `tx-sender` versus another Clarity keyword, `contract-caller` , is always a tricky concept because it determines who actually initiated the transaction versus who invoked the current function. Both of them can have certain implications on security based on the context of your code.
 * Write meaningful error codes to improve error handling
 * Adopt a modular contract design approach
@@ -68,7 +68,7 @@ While contracts are immutable once deployed, you can deploy new versions of your
 ### Implement comprehensive testing tools
 
 * [**Unit tests**](../clarinet/testing-with-clarinet-sdk.md)
-* [**Fuzzing**](/broken/pages/h06OJd7RHqUk2Dq7DHwJ)
+* [**Fuzzing**](../rendezvous/overview.md)
 * [**Devnet**](../clarinet/local-blockchain-development.md)
 {% endstep %}
 

--- a/docs/build/get-started/path-to-production.md
+++ b/docs/build/get-started/path-to-production.md
@@ -131,7 +131,7 @@ To ensure a smooth deployment process, adopt lean DevOps strategies, which inclu
 {% step %}
 ### Monitor contract activity
 
-* [**Chainhooks**](https://docs.hiro.so/en/tools/chainhooks): Chainhooks is a webhook service for the Stacks blockchain that lets you register event streams and define precise filters to capture on-chain data as it happens.
+* [**Chainhooks**](../chainhooks/overview.md): Chainhooks is a webhook service for the Stacks blockchain that lets you register event streams and define precise filters to capture on-chain data as it happens.
 {% endstep %}
 
 {% step %}

--- a/docs/build/stacks-devtools-catalog.md
+++ b/docs/build/stacks-devtools-catalog.md
@@ -107,7 +107,7 @@ Official Stacks devtools are built and maintained by either **Stacks Labs** or *
 
 * [**Explorer**](https://github.com/stx-labs/explorer) **\[StacksLabs] -** Explore transactions and accounts on the Stacks blockchain. Clone any contract and experiment in your browser with the Explorer sandbox.
 * [**Platform**](https://www.hiro.so/platform) **\[Hiro]** – Manage API keys, Chainhooks, and analyze onchain data streams in one command center.
-* [**Contract Monitoring**](contract-monitoring/README.md) **\[Hiro]** – Configure indexed contract alerts in Hiro Platform and route them to email or Slack.
+* [**Contract Monitoring**](hiro-platform/contract-monitoring/README.md) **\[Hiro]** – Configure indexed contract alerts in Hiro Platform and route them to email or Slack.
 
 <details>
 

--- a/docs/build/stacks-devtools-catalog.md
+++ b/docs/build/stacks-devtools-catalog.md
@@ -57,8 +57,8 @@ Official Stacks devtools are built and maintained by either **Stacks Labs** or *
 ### Indexing & Data
 
 * [**Stacks Blockchain APIs**](https://github.com/hirosystems/stacks-blockchain-api) **\[Hiro]** – High-performance APIs to query blockchain data, explore blocks, transactions, smart contracts, and more, without running your own node.
-* [**Token Metadata APIs**](https://github.com/hirosystems/token-metadata-api) **\[Hiro] -** Fetch metadata for every token on Stacks and effortlessly put tokens into your app. Verify and display tokens in your app, for everything from DeFi to NFTs.&#x20;
-* [**Chainhooks**](https://github.com/hirosystems/chainhook) **\[Hiro]** – A notification service for dApps that triggers webhooks on specific blockchain events, helping you respond to transactions, contract calls, and chain reorganizations in real time.
+* [**Token Metadata APIs**](https://github.com/stx-labs/token-metadata-api) **\[Hiro] -** Fetch metadata for every token on Stacks and effortlessly put tokens into your app. Verify and display tokens in your app, for everything from DeFi to NFTs.&#x20;
+* [**Chainhooks**](chainhooks/overview.md) **\[Hiro]** – A notification service for dApps that triggers webhooks on specific blockchain events, helping you respond to transactions, contract calls, and chain reorganizations in real time.
 
 <details>
 
@@ -68,7 +68,7 @@ Official Stacks devtools are built and maintained by either **Stacks Labs** or *
 * [**BNS**](https://www.bnsv2.com/docs) - [API](https://github.com/Strata-Labs/bnsv2-api) and [SDK](https://github.com/Strata-Labs/bns-v2-sdk) documentation for BNSv2, covering how to programmatically register, resolve, and manage Bitcoin Name System identities using on-chain contracts and developer libraries.
 * [**Signal21**](https://signal21.io/) - Data analytics platform for the Bitcoin Economy: on-chain visibility into Bitcoin L1, L2s, and Dapps.
 * [**Velar Devtools**](https://docs.velar.com/velar/developers) - Velar SDK and APIs allowing developers to implement token swaps, manage liquidity, and interact with the Velar DEX/DeFi ecosystem.
-* [**Bitcoin Indexer**](https://github.com/hirosystems/bitcoin-indexer) **-** Index Bitcoin meta-protocols like Ordinals, BRC-20, and Runes.
+* **Bitcoin Indexer** **\[Deprecated]** - Deprecated in March 2026 and not part of the active Stacks docs migration.
 * [**Bitflow Devtools**](https://docs.bitflow.finance/bitflow-documentation/developers/overview) - Documentation on Bitflow's SDKs and contracts for interacting with Bitflow's DeFi ecosystem.
 * [**x402-Stacks**](https://github.com/tony1908/x402Stacks) - A TypeScript library for implementing the x402 payment protocol on Stacks blockchain.&#x20;
 * [**StacksAgent MCP**](https://github.com/kai-builder/stacksagent-mcp) - A Model Context Protocol (MCP) server that enables Claude Desktop to interact with the Stacks blockchain.
@@ -95,7 +95,7 @@ Official Stacks devtools are built and maintained by either **Stacks Labs** or *
 * [**Sign-In with Stacks**](https://github.com/pradel/sign-in-with-stacks/) - A library for creating and verifying Sign-In with Stacks messages.
 * [**sBTC Pay**](https://github.com/STX-CITY/sbtc-pay) - A complete "Stripe for sBTC" payment gateway that enables businesses to easily accept Bitcoin payments via sBTC on Stacks blockchain.
 * [**Bolt Protocol**](https://github.com/ronoel/bolt-protocol) - Bolt Protocol is a next-generation framework designed to enable near-instant transactions on the Bitcoin network and enable users to pay fees directly in sBTC.
-* [**Multisig CLI**](https://github.com/hirosystems/multisig-cli/) - Command line utility written in NodeJS for creating and signing Stacks multisig transactions with a Ledger device
+* [**Multisig CLI**](https://github.com/stx-labs/multisig-cli/) - Command line utility written in NodeJS for creating and signing Stacks multisig transactions with a Ledger device
 * [**Stacks Address Generator**](https://github.com/ECBSJ/stacks-address-generator) - Simple web app to quickly generate Stacks addresses
 * [**Stacks Electrum Plugin**](https://github.com/rafa-stacks/stacks-electrum-plugin) - An Electrum wallet plugin for composing Stacks blockchain transactions via Bitcoin `OP_RETURN` encoding, as defined in SIP-001 and SIP-007.
 
@@ -107,6 +107,7 @@ Official Stacks devtools are built and maintained by either **Stacks Labs** or *
 
 * [**Explorer**](https://github.com/stx-labs/explorer) **\[StacksLabs] -** Explore transactions and accounts on the Stacks blockchain. Clone any contract and experiment in your browser with the Explorer sandbox.
 * [**Platform**](https://www.hiro.so/platform) **\[Hiro]** – Manage API keys, Chainhooks, and analyze onchain data streams in one command center.
+* [**Contract Monitoring**](contract-monitoring/README.md) **\[Hiro]** – Configure indexed contract alerts in Hiro Platform and route them to email or Slack.
 
 <details>
 
@@ -120,7 +121,7 @@ Official Stacks devtools are built and maintained by either **Stacks Labs** or *
 
 ### Docs & Standards
 
-* [**Hiro Docs**](https://docs.hiro.so/) **\[Hiro]** - Official Hiro developer documentation website.
+* [**Hiro APIs on Stacks Docs**](../reference/api/stacks-blockchain-api/README.md) **\[Hiro]** - Hiro-hosted APIs are being consolidated into the Stacks docs experience.
 * [**Stacks Docs**](https://docs.stacks.co/) **\[StacksLabs]** - Official Stacks developer documentation website.
 * [**SIPs**](https://github.com/stacksgov/sips) - Community-submitted Stacks Improvement Proposals (SIPs).
 


### PR DESCRIPTION
## Summary
- Updates remaining cross-references in 3 files to point to locally migrated content
- Scanned all remaining `docs.hiro.so` links; ~12 intentionally left external (Clarinet, stacks-cli, etc.)
- Marks Bitcoin Indexer as deprecated in devtools catalog

## Files Modified (3)
- `docs/build/get-started/developer-quickstart.md` - 3 link updates (2 Chainhooks, 1 API reference)
- `docs/build/get-started/path-to-production.md` - 1 link update (Chainhooks)
- `docs/build/stacks-devtools-catalog.md` - 5 updates (Chainhooks, Contract Monitoring, Token Metadata repo rename, Bitcoin Indexer deprecation, Hiro APIs reference)

## Context
PR 7 of 7 (final) decomposing the Hiro docs migration (#1847). This is the "glue" PR that wires up cross-references spanning multiple migration PRs. Depends on all previous PRs.

## Full Migration PR Set
1. #1850 - Broken link fixes
2. #1851 - Shared API infrastructure (keys, rate limits, headers)
3. #1855 - Chainhooks guide (13 files)
4. #1854 - Remaining API references (Chainhooks, Signer Metrics, Token Metadata)
5. #1853 - Developer tutorials (relocated to correct sections)
6. #1852 - Hiro Platform section (Contract Monitoring)
7. This PR - Final cross-reference wiring

## Test plan
- [ ] Verify all updated links resolve to files that exist after PRs 1-6 merge
- [ ] Verify remaining external Hiro links are for non-migrated content
- [ ] Run markdown link checker

🤖 Generated with [Claude Code](https://claude.com/claude-code)