### PR TITLE
Update to the latest sbtc signers' address

### DIFF
--- a/docs/build/more-guides/sbtc/bridging-bitcoin/btc-to-sbtc.md
+++ b/docs/build/more-guides/sbtc/bridging-bitcoin/btc-to-sbtc.md
@@ -108,7 +108,7 @@ This guide assumes you have a front-end bootstrapped with the Stacks Connect lib
 {% step %}
 #### Building the sBTC deposit address
 
-You're not directly sending bitcoin to the public sBTC Signers' [bitcoin address](https://mempool.space/address/bc1prcs82tvrz70jk8u79uekwdfjhd0qhs2mva6e526arycu7fu25zsqhyztuy), but rather sending to a custom P2TR address where both the user and sBTC Signers have control over. This custom P2TR address is special because it contains tapscripts that specify which parties are able to unlock the UTXOs via a script path spend.
+You're not directly sending bitcoin to the public sBTC Signers' [bitcoin address](https://mempool.space/address/bc1p6ys2ervatu00766eeqfmverzegg9fkprn3xjn0ppn70h53qu5vus3yzl0x), but rather sending to a custom P2TR address where both the user and sBTC Signers have control over. This custom P2TR address is special because it contains tapscripts that specify which parties are able to unlock the UTXOs via a script path spend.
 
 The construction of these tapscripts is what ultimately generates the custom P2TR address that the user will be sending their UTXOs to. Constructing tapscripts, or bitcoin scripts in general, are complex and tricky. The `sbtc` library provides useful methods for abstracting away the complexities of working with taproot related functions.
 
@@ -276,7 +276,7 @@ And that's all to it. You've successfully allowed your app to handle incoming BT
 
 ### What scripts make up the custom P2TR bitcoin address?
 
-As mentioned above, you're not directly sending bitcoin to the public sBTC Signers' [bitcoin address](https://mempool.space/address/bc1prcs82tvrz70jk8u79uekwdfjhd0qhs2mva6e526arycu7fu25zsqhyztuy), but rather sending to a custom P2TR address where both the user and sBTC Signers have control over. Besides the default key path spend, this custom P2TR address also contains 2 sets of scripts:
+As mentioned above, you're not directly sending bitcoin to the public sBTC Signers' [bitcoin address](https://mempool.space/address/bc1p6ys2ervatu00766eeqfmverzegg9fkprn3xjn0ppn70h53qu5vus3yzl0x), but rather sending to a custom P2TR address where both the user and sBTC Signers have control over. Besides the default key path spend, this custom P2TR address also contains 2 sets of scripts:
 
 <div data-with-frame="true"><figure><img src="../../../.gitbook/assets/custom-taproot-deposit-address.jpeg" alt=""><figcaption></figcaption></figure></div>
 

--- a/docs/learn/sbtc/README.md
+++ b/docs/learn/sbtc/README.md
@@ -51,7 +51,7 @@ sBTC is a [SIP-010](https://github.com/stacksgov/sips/blob/main/sips/sip-010/sip
 The sBTC UTXO is the single unspent transaction output (UTXO) on the Bitcoin blockchain that holds the entire BTC balance pegged into sBTC. This UTXO is managed and maintained by the set of sBTC Signers.
 
 This UTXO resides in a secure multi-signature taproot address controlled by the sBTC Signers:\
-[bc1prcs82tvrz70jk8u79uekwdfjhd0qhs2mva6e526arycu7fu25zsqhyztuy](https://mempool.space/address/bc1prcs82tvrz70jk8u79uekwdfjhd0qhs2mva6e526arycu7fu25zsqhyztuy)
+[bc1p6ys2ervatu00766eeqfmverzegg9fkprn3xjn0ppn70h53qu5vus3yzl0x](https://mempool.space/address/bc1p6ys2ervatu00766eeqfmverzegg9fkprn3xjn0ppn70h53qu5vus3yzl0x)
 
 </details>
 

--- a/docs/learn/sbtc/sbtc-signers.md
+++ b/docs/learn/sbtc/sbtc-signers.md
@@ -4,7 +4,7 @@ The Peg Wallet UTXO is a fundamental element of the sBTC system, serving as the 
 
 {% hint style="info" %}
 This UTXO resides in a secure multi-signature taproot address controlled by the sBTC Signers:\
-[bc1prcs82tvrz70jk8u79uekwdfjhd0qhs2mva6e526arycu7fu25zsqhyztuy](https://mempool.space/address/bc1prcs82tvrz70jk8u79uekwdfjhd0qhs2mva6e526arycu7fu25zsqhyztuy)
+[bc1p6ys2ervatu00766eeqfmverzegg9fkprn3xjn0ppn70h53qu5vus3yzl0x](https://mempool.space/address/bc1p6ys2ervatu00766eeqfmverzegg9fkprn3xjn0ppn70h53qu5vus3yzl0x)
 {% endhint %}
 
 ## Overview


### PR DESCRIPTION
## Description

The sBTC signers' aggregate address has changed to the one listed in this PR, you can see it here: https://mempool.space/address/bc1p6ys2ervatu00766eeqfmverzegg9fkprn3xjn0ppn70h53qu5vus3yzl0x. All the funds deposited to the old address have moved to the new one.